### PR TITLE
ENH: Provide models with dropout

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -43,9 +43,10 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --ignore=F401 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars
+          # wide.  Python 'black' defaults to a line length of 88 characters.
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
 
       - name: Test with pytest
         run: |

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -104,7 +104,7 @@ class GenericModelHandler(AbstractModelHandler):
 
 class TensorFlowModelHandler(GenericModelHandler):
     """
-    TensorFlowModelHandler is the class that implements framework-agnostic
+    TensorFlowModelHandler is the class that implements framework-dependent
     GenericModelHandler routines via TensorFlow.
     """
 
@@ -165,7 +165,7 @@ class TensorFlowModelHandler(GenericModelHandler):
 
 class PyTorchModelHandler(GenericModelHandler):
     """
-    PyTorchModelHandler is the class that implements framework-agnostic
+    PyTorchModelHandler is the class that implements framework-dependent
     GenericModelHandler routines via PyTorch.
     """
 

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -43,7 +43,7 @@ def test_dataset_handler_interface():
     # Try trivial exercises on the handler interface
     for DatasetHandler in (alb.dataset.GenericDatasetHandler,):
         my_dataset_handler = DatasetHandler()
-        exercise_database_handler(my_dataset_handler, **parameters)
+        exercise_dataset_handler(my_dataset_handler, **parameters)
 
 
 def test_model_handler_interface():
@@ -127,11 +127,19 @@ def test_handler_combinations():
     ):
         for model_creator, ModelHandler in (
             (
-                create_tensorflow_model,
+                create_toy_tensorflow_model,
                 alb.model.TensorFlowModelHandler,
             ),
             (
-                create_pytorch_model,
+                create_toy_pytorch_model,
+                alb.model.PyTorchModelHandler,
+            ),
+            (
+                create_tensorflow_model_with_dropout,
+                alb.model.TensorFlowModelHandler,
+            ),
+            (
+                create_pytorch_model_with_dropout,
                 alb.model.PyTorchModelHandler,
             ),
         ):
@@ -229,8 +237,12 @@ def create_dataset(
     return my_features, my_label_definitions, my_labels
 
 
-def create_tensorflow_model(
-    number_of_features, number_of_categories_by_label, label_to_test, **kwargs
+def create_toy_tensorflow_model(
+    number_of_features,
+    number_of_categories_by_label,
+    label_to_test,
+    hidden_units=128,
+    **kwargs,
 ):
     """
     Create a toy TensorFlow model that has the right shape for inputs and outputs
@@ -241,7 +253,7 @@ def create_tensorflow_model(
     model = tf.keras.models.Sequential(
         [
             tf.keras.Input(shape=(number_of_features,)),
-            tf.keras.layers.Dense(128, activation="relu"),
+            tf.keras.layers.Dense(hidden_units, activation="relu"),
             tf.keras.layers.Dense(number_of_categories, activation="softmax"),
         ],
         name=f"{number_of_categories}_labels_from_{number_of_features}_features",
@@ -249,8 +261,43 @@ def create_tensorflow_model(
     return model
 
 
-def create_pytorch_model(
-    number_of_features, number_of_categories_by_label, label_to_test, **kwargs
+def create_tensorflow_model_with_dropout(
+    number_of_features,
+    number_of_categories_by_label,
+    label_to_test,
+    hidden_units=32,
+    dropout=0.3,
+    noise_shape=None,
+    seed=145,
+    **kwargs,
+):
+    """
+    Create a toy TensorFlow model that has the right shape for inputs and outputs
+    """
+    import tensorflow as tf
+
+    number_of_categories = number_of_categories_by_label[label_to_test]
+    model = tf.keras.models.Sequential(
+        [
+            tf.keras.Input(shape=(number_of_features,)),
+            tf.keras.layers.Dense(hidden_units, activation="relu"),
+            tf.keras.layers.Dropout(dropout, noise_shape=noise_shape, seed=seed),
+            tf.keras.layers.Dense(number_of_categories, activation="softmax"),
+        ],
+        name=(
+            f"{number_of_categories}_labels_from_{number_of_features}_features_with_"
+            f"dropout_{dropout}"
+        ),
+    )
+    return model
+
+
+def create_toy_pytorch_model(
+    number_of_features,
+    number_of_categories_by_label,
+    label_to_test,
+    hidden_units=128,
+    **kwargs,
 ):
     """
     Create a toy PyTorch model that has the right shape for inputs and outputs
@@ -260,9 +307,9 @@ def create_pytorch_model(
     class TorchToy(torch.nn.modules.module.Module):
         def __init__(self, number_of_features, number_of_categories):
             super(TorchToy, self).__init__()
-            self.fc1 = torch.nn.Linear(number_of_features, 128)
+            self.fc1 = torch.nn.Linear(number_of_features, hidden_units)
             self.relu1 = torch.nn.ReLU()
-            self.fc2 = torch.nn.Linear(128, number_of_categories)
+            self.fc2 = torch.nn.Linear(hidden_units, number_of_categories)
             self.softmax1 = torch.nn.Softmax(dim=-1)
 
         def forward(self, x):
@@ -277,7 +324,44 @@ def create_pytorch_model(
     return model
 
 
-def exercise_database_handler(
+def create_pytorch_model_with_dropout(
+    number_of_features,
+    number_of_categories_by_label,
+    label_to_test,
+    hidden_units=32,
+    dropout=0.3,
+    noise_shape=None,
+    seed=145,
+    **kwargs,
+):
+    """
+    Create a toy PyTorch model that has the right shape for inputs and outputs
+    """
+    import torch
+
+    class TorchToyWithDropout(torch.nn.modules.module.Module):
+        def __init__(self, number_of_features, number_of_categories):
+            super(TorchToyWithDropout, self).__init__()
+            self.fc1 = torch.nn.Linear(number_of_features, hidden_units)
+            self.relu1 = torch.nn.ReLU()
+            self.dropout1 = torch.nn.Dropout(p=dropout)
+            self.fc2 = torch.nn.Linear(hidden_units, number_of_categories)
+            self.softmax1 = torch.nn.Softmax(dim=-1)
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.relu1(x)
+            x = self.dropout1(x)
+            x = self.fc2(x)
+            x = self.softmax1(x)
+            return x
+
+    number_of_categories = number_of_categories_by_label[label_to_test]
+    model = TorchToyWithDropout(number_of_features, number_of_categories)
+    return model
+
+
+def exercise_dataset_handler(
     my_dataset_handler,
     number_of_superpixels,
     number_of_features,
@@ -285,20 +369,24 @@ def exercise_database_handler(
     label_to_test,
     **kwargs,
 ):
-    # Write me!!! to test read_all_features_from_h5py(self, filename, data_name="features"):
-    # Write me!!! to test write_all_features_to_h5py(self, filename, data_name="features"):
-    # Write me!!! to test set_some_features(self, feature_indices, features):
-    # Write me!!! to test get_some_features(self, feature_indices):
-    # Write me!!! to test read_all_labels_from_h5py(self, filename, data_name="labels"):
-    # Write me!!! to test write_all_labels_to_h5py(self, filename, data_name="labels"):
-    # Write me!!! to test set_some_labels(self, label_indices, labels):
-    # Write me!!! to test get_some_labels(self, label_indices):
-    # Write me!!! to test set_all_dictionaries(self, dictionaries):
-    # Write me!!! to test get_all_dictionaries(self):
-    # Write me!!! to test clear_all_dictionaries(self):
-    # Write me!!! to test set_some_dictionaries(self, dictionary_indices, dictionaries):
-    # Write me!!! to test get_some_dictionaries(self, dictionary_indices):
-    # Write me!!! to test get_all_label_definitions(self):
+    print(
+        f"exercise_dataset_handler on type(my_dataset_handler) = "
+        f"{type(my_dataset_handler)}"
+    )
+    # !!! Test read_all_features_from_h5py(self, filename, data_name="features"):
+    # !!! Test write_all_features_to_h5py(self, filename, data_name="features"):
+    # !!! Test set_some_features(self, feature_indices, features):
+    # !!! Test get_some_features(self, feature_indices):
+    # !!! Test read_all_labels_from_h5py(self, filename, data_name="labels"):
+    # !!! Test write_all_labels_to_h5py(self, filename, data_name="labels"):
+    # !!! Test set_some_labels(self, label_indices, labels):
+    # !!! Test get_some_labels(self, label_indices):
+    # !!! Test set_all_dictionaries(self, dictionaries):
+    # !!! Test get_all_dictionaries(self):
+    # !!! Test clear_all_dictionaries(self):
+    # !!! Test set_some_dictionaries(self, dictionary_indices, dictionaries):
+    # !!! Test get_some_dictionaries(self, dictionary_indices):
+    # !!! Test get_all_label_definitions(self):
 
     # raise NotImplementedError("Not implemented")
     assert my_dataset_handler.get_all_features() is None
@@ -336,37 +424,44 @@ def exercise_model_handler(
 ):
     import al_bench as alb
 
+    print(
+        f"exercise_model_handler on type(my_model_handler) = "
+        f"{type(my_model_handler)}"
+    )
     model = None
     if isinstance(my_model_handler, alb.model.TensorFlowModelHandler):
-        model = create_tensorflow_model(
+        model = create_toy_tensorflow_model(
             number_of_features, number_of_categories_by_label, label_to_test
         )
     if isinstance(my_model_handler, alb.model.PyTorchModelHandler):
-        model = create_pytorch_model(
+        model = create_toy_pytorch_model(
             number_of_features, number_of_categories_by_label, label_to_test
         )
     my_model_handler.set_model(model)
 
-    # Write me!!! to test set_dataset_handler(self, dataset_handler):
-    # Write me!!! to test set_training_parameters(self):
-    # Write me!!! to test train(self):
-    # Write me!!! to test predict(self):
+    # !!! Test set_dataset_handler(self, dataset_handler):
+    # !!! Test set_training_parameters(self):
+    # !!! Test train(self):
+    # !!! Test predict(self):
 
 
 def exercise_strategy_handler(my_strategy_handler, **kwargs):
-    # print(f"exercise_strategy_handler with {type(my_strategy_handler) =}")
-    # Write me!!! to test set_dataset_handler(self, dataset_handler):
-    # Write me!!! to test get_dataset_handler(self):
-    # Write me!!! to test set_model_handler(self, model_handler):
-    # Write me!!! to test get_model_handler(self):
-    # Write me!!! to test set_desired_outputs(self):
-    # Write me!!! to test set_scoring_metric(self, scoring_metric):
-    # Write me!!! to test get_scoring_metric(self):
-    # Write me!!! to test clear_scoring_metric(self):
-    # Write me!!! to test set_diversity_metric(self, diversity_metric):
-    # Write me!!! to test get_diversity_metric(self):
-    # Write me!!! to test clear_diversity_metric(self):
-    # Write me!!! to test select_next_examples(self, currently_labeled_examples):
+    print(
+        f"exercise_strategy_handler on type(my_strategy_handler) = "
+        f"{type(my_strategy_handler)}"
+    )
+    # !!! Test set_dataset_handler(self, dataset_handler):
+    # !!! Test get_dataset_handler(self):
+    # !!! Test set_model_handler(self, model_handler):
+    # !!! Test get_model_handler(self):
+    # !!! Test set_desired_outputs(self):
+    # !!! Test set_scoring_metric(self, scoring_metric):
+    # !!! Test get_scoring_metric(self):
+    # !!! Test clear_scoring_metric(self):
+    # !!! Test set_diversity_metric(self, diversity_metric):
+    # !!! Test get_diversity_metric(self):
+    # !!! Test clear_diversity_metric(self):
+    # !!! Test select_next_examples(self, currently_labeled_examples):
     pass
 
 


### PR DESCRIPTION
Add one model each for tensorflow and pytorch to include a dropout layer.  This is for use with superpixel feature vectors.