### PR TITLE
Support validation dataset

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -11,9 +11,12 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
         include:
-          - flake8-python-git-tag: "<4.0.0"
-          - itk-python-git-tag: "~=5.2.0"
-          - pytest-python-git-tag: "<7.0.0"
+          - flake8-python-git-tag: ""
+          - itk-python-git-tag: ""
+          - pytest-python-git-tag: ""
+          - importlib-metadata-python-git-tag: ""
+          - tensorflow-python-git-tag: ""
+          - torch-python-git-tag: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +37,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'tensorflow' 'torch'
+          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'importlib-metadata${{ matrix.importlib-metadata-python-git-tag }}'
+          pip install 'tensorflow${{ matrix.tensorflow-python-git-tag }}' 'torch${{ matrix.torch-python-git-tag }}'
 
       - name: Install al_bench
         run: |

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -30,45 +30,58 @@ class AbstractDatasetHandler:
             "Abstract method AbstractDatasetHandler::__init__ should not be called."
         )
 
-    def read_all_features_from_h5py(self, filename, data_name="features"):
+    def read_all_feature_vectors_from_h5py(self, filename, data_name="features"):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::read_all_features_from_h5py "
+            "Abstract method "
+            "AbstractDatasetHandler::read_all_feature_vectors_from_h5py should not be "
+            "called."
+        )
+
+    def write_all_feature_vectors_to_h5py(self, filename, data_name="features"):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::write_all_feature_vectors_to_h5py "
             "should not be called."
         )
 
-    def write_all_features_to_h5py(self, filename, data_name="features"):
+    def set_all_feature_vectors(self, feature_vectors):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::write_all_features_to_h5py "
+            "Abstract method AbstractDatasetHandler::set_all_feature_vectors "
             "should not be called."
         )
 
-    def set_all_features(self, features):
+    def get_all_feature_vectors(self):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::set_all_features "
+            "Abstract method AbstractDatasetHandler::get_all_feature_vectors "
             "should not be called."
         )
 
-    def get_all_features(self):
+    def clear_all_feature_vectors(self):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::get_all_features "
+            "Abstract method AbstractDatasetHandler::clear_all_feature_vectors "
             "should not be called."
         )
 
-    def clear_all_features(self):
+    def set_some_feature_vectors(self, feature_vector_indices, feature_vectors):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::clear_all_features "
+            "Abstract method AbstractDatasetHandler::set_some_feature_vectors "
             "should not be called."
         )
 
-    def set_some_features(self, feature_indices, features):
+    def get_some_feature_vectors(self, feature_vector_indices):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::set_some_features "
+            "Abstract method AbstractDatasetHandler::get_some_feature_vectors "
             "should not be called."
         )
 
-    def get_some_features(self, feature_indices):
+    def get_training_feature_vectors(self):
         raise NotImplementedError(
-            "Abstract method AbstractDatasetHandler::get_some_features "
+            "Abstract method AbstractDatasetHandler::get_training_feature_vectors "
+            "should not be called."
+        )
+
+    def get_validation_feature_vectors(self):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::get_validation_feature_vectors "
             "should not be called."
         )
 
@@ -114,6 +127,18 @@ class AbstractDatasetHandler:
             "should not be called."
         )
 
+    def get_training_labels(self):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::get_training_labels "
+            "should not be called."
+        )
+
+    def get_validation_labels(self):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::get_validation_labels "
+            "should not be called."
+        )
+
     def set_all_dictionaries(self, dictionaries):
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_dictionaries "
@@ -144,6 +169,24 @@ class AbstractDatasetHandler:
             "should not be called."
         )
 
+    def set_validation_indices(self, validation_indices):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::set_validation_indices "
+            "should not be called."
+        )
+
+    def get_validation_indices(self):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::get_validation_indices "
+            "should not be called."
+        )
+
+    def clear_validation_indices(self):
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::clear_validation_indices "
+            "should not be called."
+        )
+
     def set_all_label_definitions(self, label_definitions):
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_label_definitions "
@@ -166,76 +209,100 @@ class AbstractDatasetHandler:
 class GenericDatasetHandler(AbstractDatasetHandler):
     def __init__(self):
         # super(GenericDatasetHandler, self).__init__()
-        self.features = None
+        self.feature_vectors = None
         self.labels = None
         self.dictionaries = None
         self.label_definitions = None
+        self.validation_indices = None
 
     """
     Handle the vector of features for each stored entity.
     """
 
-    def read_all_features_from_h5py(self, filename, data_name="features"):
+    def read_all_feature_vectors_from_h5py(self, filename, data_name="features"):
         """
         Read the entire database of features from a supplied h5py file.
         """
         with h5.File(filename) as ds:
-            self.features = np.array(ds[data_name])
+            self.feature_vectors = np.array(ds[data_name])
 
-    def write_all_features_to_h5py(self, filename, data_name="features"):
+    def write_all_feature_vectors_to_h5py(self, filename, data_name="features"):
         """
         Write the entire database of features to a h5py file.
         """
         with h5.File(filename, "w") as f:
-            f.create_dataset(data_name, self.features.shape, data=self.features)
+            f.create_dataset(
+                data_name, self.feature_vectors.shape, data=self.feature_vectors
+            )
 
-    def set_all_features(self, features):
+    def set_all_feature_vectors(self, feature_vectors):
         """
-        Set the entire database of features from a supplied numpy array.
+        Set the entire database of feature vectors from a supplied numpy array.
         """
-        if isinstance(features, np.ndarray) and len(features.shape) == 2:
-            self.features = features
+        if isinstance(feature_vectors, np.ndarray) and len(feature_vectors.shape) == 2:
+            self.feature_vectors = feature_vectors
         else:
             raise ValueError(
-                "The argument to set_all_features must be a 2-dimensional numpy "
+                "The argument to set_all_feature_vectors must be a 2-dimensional numpy "
                 "ndarray."
             )
 
-    def get_all_features(self):
+    def get_all_feature_vectors(self):
         """
-        Get the entire database of features as a numpy array.
+        Get the entire database of feature vectors as a numpy array.
         """
-        return self.features
+        return self.feature_vectors
 
-    def clear_all_features(self):
+    def clear_all_feature_vectors(self):
         """
-        Remove all features from the database
+        Remove all feature vectors from the database
         """
-        self.features = None
+        self.feature_vectors = None
 
-    def set_some_features(self, feature_indices, features):
+    def set_some_feature_vectors(self, feature_vector_indices, feature_vectors):
         """
-        This overwrites existing features.  It does not (yet) handle insert, delete, or
-        append.
+        This overwrites existing feature vectors.  It does not (yet) handle insert,
+        delete, or append.
 
-        N.B. as with numpy arrays in general, a single feature index and a list with one
-        feature index will have different behaviors, in that the former drops an array
-        dimension but the latter does not.  That is, when changing one feature use
-        feature_indices=5, features=[3,1.2,4] OR use feature_indices=[5],
-        features=[[3,1.2,4]].
+        N.B. as with numpy arrays in general, a single feature vector index and a list
+        with one feature vector index will have different behaviors, in that the former
+        drops an array dimension but the latter does not.  That is, when changing one
+        feature vector use feature_vector_indices=5, feature_vectors=[3,1.2,4] OR use
+        feature_vector_indices=[5], feature_vectors=[[3,1.2,4]].
         """
-        self.features[feature_indices] = features
+        self.feature_vectors[feature_vector_indices] = feature_vectors
 
-    def get_some_features(self, feature_indices):
+    def get_some_feature_vectors(self, feature_vector_indices):
         """
-        This fetches a subset of existing features.
+        This fetches a subset of existing feature_vectors.
 
-        N.B. as with numpy arrays in general, a single feature index and a list with one
-        feature index will have different behaviors, in that the former drops an array
-        dimension but the latter does not.  That is, use of feature_indices=5 returns
-        [3,1.2,4] but use of feature_indices=[5] returns [[3,1.2,4]].
+        N.B. as with numpy arrays in general, a single feature vector index and a list
+        with one feature vector index will have different behaviors, in that the former
+        drops an array dimension but the latter does not.  That is, use of
+        feature_vector_indices=5 returns [3,1.2,4] but use of feature_vector_indices=[5]
+        returns [[3,1.2,4]].
         """
-        return self.features[feature_indices]
+        return self.feature_vectors[feature_vector_indices]
+
+    def get_training_feature_vectors(self):
+        return (
+            self.get_all_feature_vectors()
+            if self.validation_indices is None
+            else self.get_some_feature_vectors(
+                list(
+                    set(range(self.feature_vectors.shape[0])).difference(
+                        set(self.validation_indices)
+                    )
+                )
+            )
+        )
+
+    def get_validation_feature_vectors(self):
+        return (
+            None
+            if self.validation_indices is None
+            else self.get_some_feature_vectors(self.validation_indices)
+        )
 
     """
     Handle the label(s) for each stored entity.
@@ -303,6 +370,26 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         return self.labels[label_indices]
 
+    def get_training_labels(self):
+        return (
+            self.get_all_labels()
+            if self.validation_indices is None
+            else self.get_some_labels(
+                list(
+                    set(range(self.labels.shape[0])).difference(
+                        set(self.validation_indices)
+                    )
+                )
+            )
+        )
+
+    def get_validation_labels(self):
+        return (
+            None
+            if self.validation_indices is None
+            else self.get_some_labels(self.validation_indices)
+        )
+
     """
     Handle the dictionary of supplemental information for each stored entity.
     """
@@ -338,6 +425,34 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         Remove all dictionaries from the database
         """
         self.dictionaries = None
+
+    def set_validation_indices(self, validation_indices):
+        """
+        Mark which feature vectors are reserved for validation, and should not
+        participate in training.
+        """
+        if isinstance(validation_indices, (list, tuple)) and all(
+            isinstance(e, int) for e in validation_indices
+        ):
+            self.validation_indices = validation_indices
+        else:
+            raise ValueError(
+                "The argument to set_validation_indices must be a tuple or list of "
+                "integers"
+            )
+
+    def get_validation_indices(self):
+        """
+        Retrieve the indices of those feature vectors that are reserved for validation,
+        and should not participate in training.
+        """
+        return self.validation_indices
+
+    def clear_validation_indices(self):
+        """
+        Indicate that no feature vectors are reserved for validation.
+        """
+        self.validation_indices = None
 
     def set_some_dictionaries(self, dictionary_indices, dictionaries):
         """
@@ -410,13 +525,15 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         return self.label_definitions
 
     def check_data_consistency(self):
-        # Check whether among features, labels, and dictionaries that were supplied, are
-        # they for the same number of entities?
-        features_length = 0 if self.features is None else self.features.shape[0]
+        # Check whether among feature vectors, labels, and dictionaries that were
+        # supplied, are they for the same number of entities?
+        feature_vectors_length = (
+            0 if self.feature_vectors is None else self.feature_vectors.shape[0]
+        )
         labels_length = 0 if self.labels is None else self.labels.shape[0]
         dictionaries_length = 0 if self.dictionaries is None else len(self.dictionaries)
         # Eliminate duplicates
-        all_lengths = set([features_length, labels_length, dictionaries_length])
+        all_lengths = set([feature_vectors_length, labels_length, dictionaries_length])
         lengths_test = len(all_lengths) == 1 or (
             len(all_lengths) == 2 and 0 in all_lengths
         )
@@ -465,7 +582,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         mesgs = list()
         if not lengths_test:
             mesgs += [
-                f"height(features) = {features_length}, "
+                f"height(feature_vectors) = {feature_vectors_length}, "
                 f"height(labels) = {labels_length}, and "
                 f"height(dictionaries) = {dictionaries_length} do not match."
             ]

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c97782e2-22b6-492d-aadb-ea622f37ca57",
+   "id": "4ed5d4dc-ba7f-4d0d-9858-bfb08e86aec4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-09-26 08:32:15.386396: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
+      "2022-10-03 11:05:17.068973: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
      ]
     },
     {
@@ -59,9 +59,9 @@
     "\n",
     "filename = \"../test/TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py\"\n",
     "with h5.File(filename) as ds:\n",
-    "    my_features = np.array(ds[\"features\"])\n",
+    "    my_feature_vectors = np.array(ds[\"features\"])\n",
     "    print(\n",
-    "        f\"Read in {my_features.shape[0]} feature vectors of length {my_features.shape[1]}.\"\n",
+    "        f\"Read in {my_feature_vectors.shape[0]} feature vectors of length {my_feature_vectors.shape[1]}.\"\n",
     "    )\n",
     "    my_labels = np.array(ds[\"labels\"])\n",
     "    print(f\"Read in {my_labels.shape[0]} labels for the feature vectors.\")\n",
@@ -74,9 +74,10 @@
     "    }\n",
     "]\n",
     "my_dataset_handler = alb.dataset.GenericDatasetHandler()\n",
-    "my_dataset_handler.set_all_features(my_features)\n",
+    "my_dataset_handler.set_all_feature_vectors(my_feature_vectors)\n",
     "my_dataset_handler.set_all_label_definitions(my_label_definitions)\n",
-    "my_dataset_handler.set_all_labels(my_labels)"
+    "my_dataset_handler.set_all_labels(my_labels)\n",
+    "my_dataset_handler.set_validation_indices(list(range(100)))"
    ]
   },
   {
@@ -98,7 +99,7 @@
     "import tensorflow as tf\n",
     "\n",
     "number_of_categories = len(my_label_definitions[0])\n",
-    "number_of_features = my_features.shape[1]\n",
+    "number_of_features = my_feature_vectors.shape[1]\n",
     "hidden_units = 128\n",
     "dropout = 0.3"
    ]
@@ -120,10 +121,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-09-26 08:32:17.022095: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-09-26 08:32:17.022632: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-03 11:05:18.696062: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-03 11:05:18.696836: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-09-26 08:32:17.604462: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22344 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-03 11:05:19.275654: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22344 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -277,20 +278,21 @@
      "output_type": "stream",
      "text": [
       "len(log) = 1852\n",
-      "log[:3] = [{'utcnow': datetime.datetime(2022, 9, 26, 12, 32, 18, 646768), 'model_step': <ModelStep.ON_PREDICT_BEGIN: 300>, 'logs': None}, {'utcnow': datetime.datetime(2022, 9, 26, 12, 32, 18, 663703), 'model_step': <ModelStep.ON_PREDICT_END: 305>, 'logs': {'outputs': array([[0.29915375, 0.24438834, 0.23698705, 0.21947087],\n",
-      "       [0.2740577 , 0.23741184, 0.24258009, 0.2459503 ],\n",
-      "       [0.2927576 , 0.23967767, 0.24158762, 0.22597717],\n",
-      "       ...,\n",
-      "       [0.30666745, 0.22335894, 0.248528  , 0.22144566],\n",
-      "       [0.29498193, 0.2238868 , 0.24112754, 0.24000369],\n",
-      "       [0.2854142 , 0.25165218, 0.24204808, 0.2208856 ]], dtype=float32)}}, {'utcnow': datetime.datetime(2022, 9, 26, 12, 32, 18, 665561), 'model_step': <ModelStep.ON_TRAIN_BEGIN: 100>, 'logs': None}]\n"
+      "len(some_log) = 15\n",
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 423608), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 1.3567502617835998, 'accuracy': 0.4, 'val_loss': 0.3134147644042969, 'val_accuracy': 0.88}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 517947), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 1.1149208903312684, 'accuracy': 0.85, 'val_loss': 0.2594191636145115, 'val_accuracy': 0.86}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 612310), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.8839207261800766, 'accuracy': 0.9, 'val_loss': 0.2105579622089863, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 759899), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.8701926127076149, 'accuracy': 0.625, 'val_loss': 0.14651696015149354, 'val_accuracy': 0.84}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 894291), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.6913263149559498, 'accuracy': 0.725, 'val_loss': 0.12410535700619221, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 26002), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.5800224557518959, 'accuracy': 0.775, 'val_loss': 0.11490411326289177, 'val_accuracy': 0.88}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 225100), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6559741662194332, 'accuracy': 0.81666666, 'val_loss': 0.11430420245043933, 'val_accuracy': 0.83}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 405977), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.5756370567406217, 'accuracy': 0.8333333, 'val_loss': 0.09562976518645883, 'val_accuracy': 0.91}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 575016), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.4636437573314955, 'accuracy': 0.8833333, 'val_loss': 0.09184815814136528, 'val_accuracy': 0.91}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 799002), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6040674254065379, 'accuracy': 0.8125, 'val_loss': 0.11415263638366013, 'val_accuracy': 0.83}}]\n"
      ]
     }
    ],
    "source": [
     "log = my_strategy_handler.get_log()\n",
     "print(f\"{len(log) = }\")\n",
-    "print(f\"{log[:3] = }\")"
+    "some_log = [\n",
+    "    element\n",
+    "    for element in log\n",
+    "    if element[\"model_step\"] == alb.model.ModelStep.ON_TRAIN_EPOCH_END\n",
+    "]\n",
+    "print(f\"{len(some_log) = }\")\n",
+    "print(f\"{some_log[:10] = }\")"
    ]
   }
  ],


### PR DESCRIPTION
Add the ability to specify a subset of the data for validation.  These validation feature vectors are a holdout dataset: they will have their `loss` and `accuracy` statistics separately tracked and they will be ineligible for selection in the active learning process.  Add some API functions:

- `get_training_feature_vectors`
- `get_validation_feature_vectors`
- `get_training_labels`
- `get_validation_labels`
- `set_validation_indices`
- `get_validation_indices`
- `clear_validation_indices`

Also change the names of some API functions to clarify that they are handling, e.g., a list of feature vectors rather than a list of individual feature values:

- `read_all_features_from_h5py` --> `read_all_feature_vectors_from_h5py`
- `write_all_features_from_h5py` --> `write_all_feature_vectors_from_h5py`
- `set_all_features` --> `set_all_feature_vectors`
- `get_all_features` --> `get_all_feature_vectors`
- `clear_all_features` --> `clear_all_feature_vectors`
- `set_some_features` --> `set_some_feature_vectors`
- `get_some_features` --> `get_some_feature_vectors`