### PR TITLE
ENH: Implement write_train_log_for_tensorboard

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,7 +14,6 @@ jobs:
           - flake8-python-git-tag: ""
           - itk-python-git-tag: ""
           - pytest-python-git-tag: ""
-          - importlib-metadata-python-git-tag: ""
           - tensorflow-python-git-tag: ""
           - torch-python-git-tag: ""
 
@@ -37,7 +36,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'importlib-metadata${{ matrix.importlib-metadata-python-git-tag }}'
+          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}'
           pip install 'tensorflow${{ matrix.tensorflow-python-git-tag }}' 'torch${{ matrix.torch-python-git-tag }}'
 
       - name: Install al_bench

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -559,7 +559,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             or (
                 len(self.labels.shape) == 1  # 1-dimensional numpy array
                 and len(
-                    set(self.labels).difference(set(self.label_definitions[0].keys()))
+                    set(self.labels).difference(set(self.label_definitions[0]))
                 )
                 == 0
             )
@@ -569,7 +569,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
                     [
                         len(
                             set(self.labels[:, col]).difference(
-                                set(self.label_definitions[col].keys())
+                                set(self.label_definitions[col])
                             )
                         )
                         == 0

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -123,11 +123,11 @@ class GenericModelHandler(AbstractModelHandler):
     def get_log(self):
         return self.custom_callback.get_log()
 
-    def write_train_log_to_tensorboard_file(self, *args, **kwargs):
-        return self.custom_callback.write_train_log_to_tensorboard_file(*args, **kwargs)
+    def write_train_log_for_tensorboard(self, *args, **kwargs):
+        return self.custom_callback.write_train_log_for_tensorboard(*args, **kwargs)
 
-    def write_epoch_log_to_tensorboard_file(self, *args, **kwargs):
-        return self.custom_callback.write_epoch_log_to_tensorboard_file(*args, **kwargs)
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs):
+        return self.custom_callback.write_epoch_log_for_tensorboard(*args, **kwargs)
 
     def set_dataset_handler(self, dataset_handler):
         if not isinstance(dataset_handler, dataset.AbstractDatasetHandler):
@@ -147,7 +147,7 @@ class GenericModelHandler(AbstractModelHandler):
 
     # Does it matter that this GenericModelHandler code requires `import torch`` because
     # of the use of torch.utils.tensorboard.SummaryWriter in
-    # GenericModelHandler.CustomCallback.write_some_log_to_tensorboard_file?!!!
+    # GenericModelHandler.CustomCallback.write_some_log_for_tensorboard?!!!
 
     class CustomCallback(keras.callbacks.Callback):
         def __init__(self):
@@ -161,7 +161,7 @@ class GenericModelHandler(AbstractModelHandler):
         def get_log(self):
             return self.log
 
-        def write_some_log_to_tensorboard_file(
+        def write_some_log_for_tensorboard(
             self, model_step, y_dictionary, x_key, *args, **kwargs
         ):
             from torch.utils.tensorboard import SummaryWriter
@@ -193,7 +193,7 @@ class GenericModelHandler(AbstractModelHandler):
                             )
             return True
 
-        def write_train_log_to_tensorboard_file(self, *args, **kwargs):
+        def write_train_log_for_tensorboard(self, *args, **kwargs):
             model_step = ModelStep.ON_TRAIN_END
             y_dictionary = dict(
                 loss="Loss/train",
@@ -202,11 +202,11 @@ class GenericModelHandler(AbstractModelHandler):
                 val_accuracy="Accuracy/test",
             )
             x_key = "training_size"
-            return self.write_some_log_to_tensorboard_file(
+            return self.write_some_log_for_tensorboard(
                 model_step, y_dictionary, x_key, *args, **kwargs
             )
 
-        def write_epoch_log_to_tensorboard_file(self, *args, **kwargs):
+        def write_epoch_log_for_tensorboard(self, *args, **kwargs):
             model_step = ModelStep.ON_TRAIN_EPOCH_END
             y_dictionary = dict(
                 loss="Loss/train",
@@ -215,7 +215,7 @@ class GenericModelHandler(AbstractModelHandler):
                 val_accuracy="Accuracy/test",
             )
             x_key = "epoch"
-            return self.write_some_log_to_tensorboard_file(
+            return self.write_some_log_for_tensorboard(
                 model_step, y_dictionary, x_key, *args, **kwargs
             )
 

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -178,8 +178,8 @@ class GenericModelHandler(AbstractModelHandler):
                         continue
                     utc_seconds = (entry["utcnow"] - beginning).total_seconds()
                     x_value = entry[x_key]
-                    for key in y_dictionary.keys():
-                        if key in logs.keys():
+                    for key in y_dictionary:
+                        if key in logs:
                             y_value = logs[key]
                             # print(
                             #     f"Invoking writer.add_scalar({y_dictionary[key]}, {y_value}, {x_value}, walltime={utc_seconds}, new_style=True)"

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -197,9 +197,9 @@ class GenericModelHandler(AbstractModelHandler):
             model_step = ModelStep.ON_TRAIN_END
             y_dictionary = dict(
                 loss="Loss/train",
-                val_loss="Loss/test",
+                val_loss="Loss/validation",
                 accuracy="Accuracy/train",
-                val_accuracy="Accuracy/test",
+                val_accuracy="Accuracy/validation",
             )
             x_key = "training_size"
             return self.write_some_log_for_tensorboard(

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -289,11 +289,11 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def get_log(self):
         return self.model_handler.get_log()
 
-    def write_train_log_to_tensorboard_file(self, *args, **kwargs):
-        return self.model_handler.write_train_log_to_tensorboard_file(*args, **kwargs)
+    def write_train_log_for_tensorboard(self, *args, **kwargs):
+        return self.model_handler.write_train_log_for_tensorboard(*args, **kwargs)
 
-    def write_epoch_log_to_tensorboard_file(self, *args, **kwargs):
-        return self.model_handler.write_epoch_log_to_tensorboard_file(*args, **kwargs)
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs):
+        return self.model_handler.write_epoch_log_for_tensorboard(*args, **kwargs)
 
     def run(self, currently_labeled_examples):
         """

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -261,13 +261,13 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 f"Python dict but is of type {type(parameters)}"
             )
 
-        missing_keys = set(self.required_parameters_keys).difference(parameters.keys())
+        missing_keys = set(self.required_parameters_keys).difference(parameters)
         if len(missing_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters missing required key(s): {missing_keys}"
             )
 
-        invalid_keys = set(parameters.keys()).difference(self.valid_parameters_keys)
+        invalid_keys = set(parameters).difference(self.valid_parameters_keys)
         if len(invalid_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters given invalid key(s): {invalid_keys}"

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -289,6 +289,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def get_log(self):
         return self.model_handler.get_log()
 
+    def write_train_log_to_tensorboard_file(self, *args, **kwargs):
+        return self.model_handler.write_train_log_to_tensorboard_file(*args, **kwargs)
+
     def write_epoch_log_to_tensorboard_file(self, *args, **kwargs):
         return self.model_handler.write_epoch_log_to_tensorboard_file(*args, **kwargs)
 

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -289,6 +289,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def get_log(self):
         return self.model_handler.get_log()
 
+    def write_epoch_log_to_tensorboard_file(self, *args, **kwargs):
+        return self.model_handler.write_epoch_log_to_tensorboard_file(*args, **kwargs)
+
     def run(self, currently_labeled_examples):
         """
         Run the strategy, start to finish.

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6a535a1-dcff-4c6b-ab4f-999ed12cdcd6",
+   "id": "c7634acd-937d-474d-afeb-f3005d981584",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-12 12:34:50.048736: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
+      "2022-10-13 11:00:35.513432: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
      ]
     },
     {
@@ -121,10 +121,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-12 12:34:51.640670: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-10-12 12:34:51.641121: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-13 11:00:37.129816: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-13 11:00:37.130356: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-12 12:34:52.235055: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-13 11:00:37.726800: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_model_handler = my_pytorch_model_handler"
+    "my_model_handler = my_tensorflow_model_handler"
    ]
   },
   {
@@ -247,7 +247,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicting for 4598 examples\n",
+      "Predicting for 4598 examples\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-10-13 11:00:40.118929: I tensorflow/stream_executor/cuda/cuda_blas.cc:1786] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Training with 20 examples\n",
       "Predicting for 4598 examples\n",
       "Training with 40 examples\n",
@@ -277,35 +290,44 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "len(log) = 1852\n",
-      "len(some_log) = 15\n",
-      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 383033), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 1.3795872390270234, 'accuracy': 0.2, 'val_loss': 0.3043838633596897, 'val_accuracy': 0.75}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 475911), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 1.1312936425209046, 'accuracy': 0.6, 'val_loss': 0.2536778987944126, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 567375), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.9175757527351379, 'accuracy': 0.8, 'val_loss': 0.21565907932817935, 'val_accuracy': 0.89}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 716867), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.9397962607443333, 'accuracy': 0.725, 'val_loss': 0.16392131350934505, 'val_accuracy': 0.87}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 848383), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.764279605448246, 'accuracy': 0.725, 'val_loss': 0.14017734851688146, 'val_accuracy': 0.86}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 978859), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.6248312851414084, 'accuracy': 0.775, 'val_loss': 0.13042781447991728, 'val_accuracy': 0.79}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 162063), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.7247496709538003, 'accuracy': 0.71666664, 'val_loss': 0.15437097918707876, 'val_accuracy': 0.74}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 337838), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.5818991577252746, 'accuracy': 0.78333336, 'val_loss': 0.11334952284116298, 'val_accuracy': 0.82}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 508427), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.5293451399542392, 'accuracy': 0.81666666, 'val_loss': 0.11583864325424656, 'val_accuracy': 0.83}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 751261), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6749952687881887, 'accuracy': 0.6875, 'val_loss': 0.0790861978859175, 'val_accuracy': 0.89}}]\n",
-      "Counter({<ModelStep.ON_TRAIN_BATCH_BEGIN: 140>: 900, <ModelStep.ON_TRAIN_BATCH_END: 145>: 900, <ModelStep.ON_TRAIN_EPOCH_BEGIN: 120>: 15, <ModelStep.ON_TRAIN_EPOCH_END: 125>: 15, <ModelStep.ON_PREDICT_BEGIN: 300>: 6, <ModelStep.ON_PREDICT_END: 305>: 6, <ModelStep.ON_TRAIN_BEGIN: 100>: 5, <ModelStep.ON_TRAIN_END: 105>: 5})\n",
-      "Counter({'utcnow model_step batch logs <ModelStep.ON_TRAIN_BATCH_BEGIN: 140>': 900, 'utcnow model_step batch logs loss accuracy <ModelStep.ON_TRAIN_BATCH_END: 145>': 900, 'utcnow model_step epoch logs <ModelStep.ON_TRAIN_EPOCH_BEGIN: 120>': 15, 'utcnow model_step epoch logs loss accuracy val_loss val_accuracy <ModelStep.ON_TRAIN_EPOCH_END: 125>': 15, 'utcnow model_step logs <ModelStep.ON_PREDICT_BEGIN: 300>': 6, 'utcnow model_step logs outputs <ModelStep.ON_PREDICT_END: 305>': 6, 'utcnow model_step logs <ModelStep.ON_TRAIN_BEGIN: 100>': 5, 'utcnow model_step logs loss accuracy val_loss val_accuracy <ModelStep.ON_TRAIN_END: 105>': 5})\n"
+      "len(log) = 2590\n",
+      "\n",
+      "len(some_log) = 5\n",
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 41, 369890), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 20, 'loss': 0.25152623653411865, 'accuracy': 0.8999999761581421, 'val_loss': 0.8194094300270081, 'val_accuracy': 0.699999988079071}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 42, 500745), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 40, 'loss': 0.03774882107973099, 'accuracy': 1.0, 'val_loss': 0.42392727732658386, 'val_accuracy': 0.8399999737739563}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 43, 706093), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 60, 'loss': 0.06042421609163284, 'accuracy': 0.9833333492279053, 'val_loss': 0.4716495871543884, 'val_accuracy': 0.800000011920929}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 45, 36061), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 80, 'loss': 0.04587779566645622, 'accuracy': 1.0, 'val_loss': 0.35647186636924744, 'val_accuracy': 0.8299999833106995}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 46, 205206), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 100, 'loss': 0.0775241106748581, 'accuracy': 0.9800000190734863, 'val_loss': 0.46908771991729736, 'val_accuracy': 0.8399999737739563}}]\n",
+      "\n",
+      "By ModelStep, set of supplied keys and number of records:\n",
+      "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 200, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 200, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step logs dataset_size loss accuracy val_loss val_accuracy': 5})\n"
      ]
     }
    ],
    "source": [
+    "# Look at the whole log\n",
     "log = my_strategy_handler.get_log()\n",
     "print(f\"{len(log) = }\")\n",
+    "\n",
+    "# Look at records for one kind of model_step\n",
+    "print(\"\")\n",
     "some_log = [\n",
     "    element\n",
     "    for element in log\n",
-    "    if element[\"model_step\"] == alb.model.ModelStep.ON_TRAIN_EPOCH_END\n",
+    "    if element[\"model_step\"] == alb.model.ModelStep.ON_TRAIN_END\n",
     "]\n",
     "print(f\"{len(some_log) = }\")\n",
     "print(f\"{some_log[:10] = }\")\n",
     "\n",
+    "# Look at each kind of model_step and what kind of keys and log keys are associated with\n",
+    "# it.\n",
     "import collections\n",
     "\n",
-    "print(collections.Counter([entry[\"model_step\"] for entry in log]))\n",
+    "print(\"\")\n",
+    "print(\"By ModelStep, set of supplied keys and number of records:\")\n",
     "print(\n",
     "    collections.Counter(\n",
     "        [\n",
     "            \" \".join(\n",
-    "                list(entry.keys())\n",
+    "                [repr(entry[\"model_step\"])]\n",
+    "                + list(entry.keys())\n",
     "                + (list(entry[\"logs\"].keys()) if entry[\"logs\"] is not None else list())\n",
-    "                + [repr(entry[\"model_step\"])]\n",
     "            )\n",
     "            for entry in log\n",
     "        ]\n",

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45733bcd-e018-4ef4-8758-950ad4384160",
+   "id": "307b4c12-b35b-4763-b484-05eeeaf5156b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,13 +40,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:41:50.250706: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-14 10:46:32.160473: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-13 13:41:50.379252: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "2022-10-13 13:41:50.415089: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "2022-10-13 13:41:50.952144: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
-      "2022-10-13 13:41:50.952241: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
-      "2022-10-13 13:41:50.952265: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
+      "2022-10-14 10:46:32.308129: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2022-10-14 10:46:32.343780: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2022-10-14 10:46:32.886980: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
+      "2022-10-14 10:46:32.887068: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
+      "2022-10-14 10:46:32.887075: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
      ]
     },
     {
@@ -130,10 +130,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:41:51.982472: I tensorflow/core/common_runtime/gpu/gpu_device.cc:2006] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-10-13 13:41:51.983007: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-14 10:46:33.892439: I tensorflow/core/common_runtime/gpu/gpu_device.cc:2006] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-14 10:46:33.892801: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-13 13:41:52.607596: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22331 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-14 10:46:34.566823: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22331 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -263,7 +263,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:41:55.311210: I tensorflow/stream_executor/cuda/cuda_blas.cc:1614] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
+      "2022-10-14 10:46:36.962443: I tensorflow/stream_executor/cuda/cuda_blas.cc:1614] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
      ]
     },
     {
@@ -310,7 +310,7 @@
       "len(log) = 3690\n",
       "\n",
       "len(some_log) = 5\n",
-      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 17, 41, 57, 114357), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 20, 'logs': {'loss': 0.11437394469976425, 'accuracy': 1.0, 'val_loss': 0.6067678332328796, 'val_accuracy': 0.758169949054718}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 41, 58, 884224), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 40, 'logs': {'loss': 0.0603439100086689, 'accuracy': 1.0, 'val_loss': 0.46318742632865906, 'val_accuracy': 0.827886700630188}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 0, 817338), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 60, 'logs': {'loss': 0.0685662180185318, 'accuracy': 1.0, 'val_loss': 0.5263730883598328, 'val_accuracy': 0.8322439789772034}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 2, 825077), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 80, 'logs': {'loss': 0.05476746708154678, 'accuracy': 1.0, 'val_loss': 0.5497345328330994, 'val_accuracy': 0.8409585952758789}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 4, 892661), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 100, 'logs': {'loss': 0.06339198350906372, 'accuracy': 0.9900000095367432, 'val_loss': 0.39767593145370483, 'val_accuracy': 0.8845316171646118}}]\n",
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 14, 14, 46, 38, 767879), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 20, 'logs': {'loss': 0.04248485714197159, 'accuracy': 1.0, 'val_loss': 1.1615086793899536, 'val_accuracy': 0.5904139280319214}}, {'utcnow': datetime.datetime(2022, 10, 14, 14, 46, 40, 554077), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 40, 'logs': {'loss': 0.013295005075633526, 'accuracy': 1.0, 'val_loss': 1.0923469066619873, 'val_accuracy': 0.7843137383460999}}, {'utcnow': datetime.datetime(2022, 10, 14, 14, 46, 42, 292039), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 60, 'logs': {'loss': 0.020124146714806557, 'accuracy': 1.0, 'val_loss': 0.9480640292167664, 'val_accuracy': 0.827886700630188}}, {'utcnow': datetime.datetime(2022, 10, 14, 14, 46, 44, 62695), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 80, 'logs': {'loss': 0.046600814908742905, 'accuracy': 1.0, 'val_loss': 0.5281912684440613, 'val_accuracy': 0.8453159332275391}}, {'utcnow': datetime.datetime(2022, 10, 14, 14, 46, 45, 742796), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 100, 'logs': {'loss': 0.06695395708084106, 'accuracy': 0.9800000190734863, 'val_loss': 0.7730088829994202, 'val_accuracy': 0.8061001896858215}}]\n",
       "\n",
       "By ModelStep, set of supplied keys and number of records:\n",
       "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 750, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 750, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step training_size logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step training_size logs loss accuracy val_loss val_accuracy': 5})\n"
@@ -353,9 +353,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5e7135fa-8548-4162-a55c-32716ffe81f7",
+   "metadata": {},
+   "source": [
+    "<h2>Use with TensorBoard</h2>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "ae2c7acc-a594-428b-a86c-a713b42c4bf9",
+   "id": "73d7cd4f-895e-49c0-b3a6-29aa08b376c0",
    "metadata": {},
    "outputs": [
     {
@@ -368,8 +376,9 @@
    ],
    "source": [
     "# Write the log\n",
-    "my_strategy_handler.write_train_log_for_tensorboard()\n",
-    "print(\"Log written to disk\")"
+    "my_strategy_handler.write_train_log_for_tensorboard() # defaults to `runs` directory\n",
+    "print(\"Log written to disk\")\n",
+    "# Examine with `tensorboard --logidr runs`"
    ]
   },
   {

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ed5d4dc-ba7f-4d0d-9858-bfb08e86aec4",
+   "id": "d6a535a1-dcff-4c6b-ab4f-999ed12cdcd6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-03 11:05:17.068973: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
+      "2022-10-12 12:34:50.048736: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
      ]
     },
     {
@@ -121,10 +121,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-03 11:05:18.696062: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-10-03 11:05:18.696836: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-12 12:34:51.640670: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-12 12:34:51.641121: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-03 11:05:19.275654: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22344 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-12 12:34:52.235055: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "eaa8d17d-f68f-4349-81f5-4c2f10d780a5",
+   "id": "cbc0fc47-a056-4581-bdc2-1be8980566db",
    "metadata": {},
    "outputs": [
     {
@@ -279,7 +279,9 @@
      "text": [
       "len(log) = 1852\n",
       "len(some_log) = 15\n",
-      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 423608), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 1.3567502617835998, 'accuracy': 0.4, 'val_loss': 0.3134147644042969, 'val_accuracy': 0.88}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 517947), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 1.1149208903312684, 'accuracy': 0.85, 'val_loss': 0.2594191636145115, 'val_accuracy': 0.86}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 612310), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.8839207261800766, 'accuracy': 0.9, 'val_loss': 0.2105579622089863, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 759899), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.8701926127076149, 'accuracy': 0.625, 'val_loss': 0.14651696015149354, 'val_accuracy': 0.84}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 20, 894291), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.6913263149559498, 'accuracy': 0.725, 'val_loss': 0.12410535700619221, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 26002), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.5800224557518959, 'accuracy': 0.775, 'val_loss': 0.11490411326289177, 'val_accuracy': 0.88}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 225100), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6559741662194332, 'accuracy': 0.81666666, 'val_loss': 0.11430420245043933, 'val_accuracy': 0.83}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 405977), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.5756370567406217, 'accuracy': 0.8333333, 'val_loss': 0.09562976518645883, 'val_accuracy': 0.91}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 575016), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.4636437573314955, 'accuracy': 0.8833333, 'val_loss': 0.09184815814136528, 'val_accuracy': 0.91}}, {'utcnow': datetime.datetime(2022, 10, 3, 15, 5, 21, 799002), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6040674254065379, 'accuracy': 0.8125, 'val_loss': 0.11415263638366013, 'val_accuracy': 0.83}}]\n"
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 383033), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 1.3795872390270234, 'accuracy': 0.2, 'val_loss': 0.3043838633596897, 'val_accuracy': 0.75}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 475911), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 1.1312936425209046, 'accuracy': 0.6, 'val_loss': 0.2536778987944126, 'val_accuracy': 0.85}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 567375), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.9175757527351379, 'accuracy': 0.8, 'val_loss': 0.21565907932817935, 'val_accuracy': 0.89}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 716867), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.9397962607443333, 'accuracy': 0.725, 'val_loss': 0.16392131350934505, 'val_accuracy': 0.87}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 848383), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.764279605448246, 'accuracy': 0.725, 'val_loss': 0.14017734851688146, 'val_accuracy': 0.86}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 53, 978859), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.6248312851414084, 'accuracy': 0.775, 'val_loss': 0.13042781447991728, 'val_accuracy': 0.79}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 162063), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.7247496709538003, 'accuracy': 0.71666664, 'val_loss': 0.15437097918707876, 'val_accuracy': 0.74}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 337838), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 1, 'logs': {'loss': 0.5818991577252746, 'accuracy': 0.78333336, 'val_loss': 0.11334952284116298, 'val_accuracy': 0.82}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 508427), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 2, 'logs': {'loss': 0.5293451399542392, 'accuracy': 0.81666666, 'val_loss': 0.11583864325424656, 'val_accuracy': 0.83}}, {'utcnow': datetime.datetime(2022, 10, 12, 16, 34, 54, 751261), 'model_step': <ModelStep.ON_TRAIN_EPOCH_END: 125>, 'epoch': 0, 'logs': {'loss': 0.6749952687881887, 'accuracy': 0.6875, 'val_loss': 0.0790861978859175, 'val_accuracy': 0.89}}]\n",
+      "Counter({<ModelStep.ON_TRAIN_BATCH_BEGIN: 140>: 900, <ModelStep.ON_TRAIN_BATCH_END: 145>: 900, <ModelStep.ON_TRAIN_EPOCH_BEGIN: 120>: 15, <ModelStep.ON_TRAIN_EPOCH_END: 125>: 15, <ModelStep.ON_PREDICT_BEGIN: 300>: 6, <ModelStep.ON_PREDICT_END: 305>: 6, <ModelStep.ON_TRAIN_BEGIN: 100>: 5, <ModelStep.ON_TRAIN_END: 105>: 5})\n",
+      "Counter({'utcnow model_step batch logs <ModelStep.ON_TRAIN_BATCH_BEGIN: 140>': 900, 'utcnow model_step batch logs loss accuracy <ModelStep.ON_TRAIN_BATCH_END: 145>': 900, 'utcnow model_step epoch logs <ModelStep.ON_TRAIN_EPOCH_BEGIN: 120>': 15, 'utcnow model_step epoch logs loss accuracy val_loss val_accuracy <ModelStep.ON_TRAIN_EPOCH_END: 125>': 15, 'utcnow model_step logs <ModelStep.ON_PREDICT_BEGIN: 300>': 6, 'utcnow model_step logs outputs <ModelStep.ON_PREDICT_END: 305>': 6, 'utcnow model_step logs <ModelStep.ON_TRAIN_BEGIN: 100>': 5, 'utcnow model_step logs loss accuracy val_loss val_accuracy <ModelStep.ON_TRAIN_END: 105>': 5})\n"
      ]
     }
    ],
@@ -292,8 +294,32 @@
     "    if element[\"model_step\"] == alb.model.ModelStep.ON_TRAIN_EPOCH_END\n",
     "]\n",
     "print(f\"{len(some_log) = }\")\n",
-    "print(f\"{some_log[:10] = }\")"
+    "print(f\"{some_log[:10] = }\")\n",
+    "\n",
+    "import collections\n",
+    "\n",
+    "print(collections.Counter([entry[\"model_step\"] for entry in log]))\n",
+    "print(\n",
+    "    collections.Counter(\n",
+    "        [\n",
+    "            \" \".join(\n",
+    "                list(entry.keys())\n",
+    "                + (list(entry[\"logs\"].keys()) if entry[\"logs\"] is not None else list())\n",
+    "                + [repr(entry[\"model_step\"])]\n",
+    "            )\n",
+    "            for entry in log\n",
+    "        ]\n",
+    "    )\n",
+    ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17176f6a-0155-4e8e-bd08-00f9e89e889b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0ffa2eb-4e8f-440b-9c60-0f3a1e4c5cfe",
+   "id": "45733bcd-e018-4ef4-8758-950ad4384160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:00:44.138064: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
+      "2022-10-13 13:41:50.250706: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-10-13 13:41:50.379252: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2022-10-13 13:41:50.415089: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2022-10-13 13:41:50.952144: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
+      "2022-10-13 13:41:50.952241: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/usr/local/cuda/lib64:/home/lee.newberg/Support/dakota-6.13.0.src-install/lib\n",
+      "2022-10-13 13:41:50.952265: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
      ]
     },
     {
@@ -56,6 +62,7 @@
     "import al_bench as alb\n",
     "import h5py as h5\n",
     "import numpy as np\n",
+    "import random\n",
     "\n",
     "filename = \"../test/TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py\"\n",
     "with h5.File(filename) as ds:\n",
@@ -77,7 +84,9 @@
     "my_dataset_handler.set_all_feature_vectors(my_feature_vectors)\n",
     "my_dataset_handler.set_all_label_definitions(my_label_definitions)\n",
     "my_dataset_handler.set_all_labels(my_labels)\n",
-    "my_dataset_handler.set_validation_indices(list(range(100)))"
+    "my_dataset_handler.set_validation_indices(\n",
+    "    random.sample(range(my_feature_vectors.shape[0]), my_feature_vectors.shape[0] // 10)\n",
+    ")"
    ]
   },
   {
@@ -121,10 +130,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:00:45.743150: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-10-13 13:00:45.743749: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-13 13:41:51.982472: I tensorflow/core/common_runtime/gpu/gpu_device.cc:2006] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-13 13:41:51.983007: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-13 13:00:46.324049: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-13 13:41:52.607596: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22331 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -254,7 +263,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 13:00:48.601600: I tensorflow/stream_executor/cuda/cuda_blas.cc:1786] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
+      "2022-10-13 13:41:55.311210: I tensorflow/stream_executor/cuda/cuda_blas.cc:1614] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
      ]
     },
     {
@@ -298,13 +307,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "len(log) = 2590\n",
+      "len(log) = 3690\n",
       "\n",
       "len(some_log) = 5\n",
-      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 49, 842915), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 20, 'logs': {'loss': 0.08719807118177414, 'accuracy': 1.0, 'val_loss': 0.2755473852157593, 'val_accuracy': 0.9200000166893005}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 51, 165403), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 40, 'logs': {'loss': 0.07815542817115784, 'accuracy': 0.9750000238418579, 'val_loss': 0.3668362498283386, 'val_accuracy': 0.7900000214576721}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 52, 484321), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 60, 'logs': {'loss': 0.09457577019929886, 'accuracy': 0.9833333492279053, 'val_loss': 0.5726461410522461, 'val_accuracy': 0.7400000095367432}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 53, 748080), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 80, 'logs': {'loss': 0.06295613944530487, 'accuracy': 0.987500011920929, 'val_loss': 0.3258470296859741, 'val_accuracy': 0.8700000047683716}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 55, 229728), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 100, 'logs': {'loss': 0.09952779114246368, 'accuracy': 0.9700000286102295, 'val_loss': 0.5298805832862854, 'val_accuracy': 0.8100000023841858}}]\n",
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 17, 41, 57, 114357), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 20, 'logs': {'loss': 0.11437394469976425, 'accuracy': 1.0, 'val_loss': 0.6067678332328796, 'val_accuracy': 0.758169949054718}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 41, 58, 884224), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 40, 'logs': {'loss': 0.0603439100086689, 'accuracy': 1.0, 'val_loss': 0.46318742632865906, 'val_accuracy': 0.827886700630188}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 0, 817338), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 60, 'logs': {'loss': 0.0685662180185318, 'accuracy': 1.0, 'val_loss': 0.5263730883598328, 'val_accuracy': 0.8322439789772034}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 2, 825077), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 80, 'logs': {'loss': 0.05476746708154678, 'accuracy': 1.0, 'val_loss': 0.5497345328330994, 'val_accuracy': 0.8409585952758789}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 42, 4, 892661), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 100, 'logs': {'loss': 0.06339198350906372, 'accuracy': 0.9900000095367432, 'val_loss': 0.39767593145370483, 'val_accuracy': 0.8845316171646118}}]\n",
       "\n",
       "By ModelStep, set of supplied keys and number of records:\n",
-      "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 200, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 200, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step training_size logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step training_size logs loss accuracy val_loss val_accuracy': 5})\n"
+      "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 750, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 750, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step training_size logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step training_size logs loss accuracy val_loss val_accuracy': 5})\n"
      ]
     }
    ],

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7634acd-937d-474d-afeb-f3005d981584",
+   "id": "f0ffa2eb-4e8f-440b-9c60-0f3a1e4c5cfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 11:00:35.513432: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
+      "2022-10-13 13:00:44.138064: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n"
      ]
     },
     {
@@ -121,10 +121,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 11:00:37.129816: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
-      "2022-10-13 11:00:37.130356: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "2022-10-13 13:00:45.743150: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1922] Ignoring visible gpu device (device: 1, name: Quadro P400, pci bus id: 0000:a6:00.0, compute capability: 6.1) with core count: 2. The minimum required count is 8. You can adjust this requirement with the env var TF_MIN_GPU_MULTIPROCESSOR_COUNT.\n",
+      "2022-10-13 13:00:45.743749: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-10-13 11:00:37.726800: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
+      "2022-10-13 13:00:46.324049: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22343 MB memory:  -> device: 0, name: NVIDIA RTX A5000, pci bus id: 0000:73:00.0, compute capability: 8.6\n"
      ]
     }
    ],
@@ -254,7 +254,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-13 11:00:40.118929: I tensorflow/stream_executor/cuda/cuda_blas.cc:1786] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
+      "2022-10-13 13:00:48.601600: I tensorflow/stream_executor/cuda/cuda_blas.cc:1786] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n"
      ]
     },
     {
@@ -281,9 +281,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "077925ca-30aa-4598-9a95-341b230374be",
+   "metadata": {},
+   "source": [
+    "<h2>Examine the log</h2>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "cbc0fc47-a056-4581-bdc2-1be8980566db",
+   "id": "31ebd076-8b26-43ad-8914-c8ae8f44f469",
    "metadata": {},
    "outputs": [
     {
@@ -293,10 +301,10 @@
       "len(log) = 2590\n",
       "\n",
       "len(some_log) = 5\n",
-      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 41, 369890), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 20, 'loss': 0.25152623653411865, 'accuracy': 0.8999999761581421, 'val_loss': 0.8194094300270081, 'val_accuracy': 0.699999988079071}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 42, 500745), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 40, 'loss': 0.03774882107973099, 'accuracy': 1.0, 'val_loss': 0.42392727732658386, 'val_accuracy': 0.8399999737739563}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 43, 706093), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 60, 'loss': 0.06042421609163284, 'accuracy': 0.9833333492279053, 'val_loss': 0.4716495871543884, 'val_accuracy': 0.800000011920929}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 45, 36061), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 80, 'loss': 0.04587779566645622, 'accuracy': 1.0, 'val_loss': 0.35647186636924744, 'val_accuracy': 0.8299999833106995}}, {'utcnow': datetime.datetime(2022, 10, 13, 15, 0, 46, 205206), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'logs': {'dataset_size': 100, 'loss': 0.0775241106748581, 'accuracy': 0.9800000190734863, 'val_loss': 0.46908771991729736, 'val_accuracy': 0.8399999737739563}}]\n",
+      "some_log[:10] = [{'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 49, 842915), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 20, 'logs': {'loss': 0.08719807118177414, 'accuracy': 1.0, 'val_loss': 0.2755473852157593, 'val_accuracy': 0.9200000166893005}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 51, 165403), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 40, 'logs': {'loss': 0.07815542817115784, 'accuracy': 0.9750000238418579, 'val_loss': 0.3668362498283386, 'val_accuracy': 0.7900000214576721}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 52, 484321), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 60, 'logs': {'loss': 0.09457577019929886, 'accuracy': 0.9833333492279053, 'val_loss': 0.5726461410522461, 'val_accuracy': 0.7400000095367432}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 53, 748080), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 80, 'logs': {'loss': 0.06295613944530487, 'accuracy': 0.987500011920929, 'val_loss': 0.3258470296859741, 'val_accuracy': 0.8700000047683716}}, {'utcnow': datetime.datetime(2022, 10, 13, 17, 0, 55, 229728), 'model_step': <ModelStep.ON_TRAIN_END: 105>, 'training_size': 100, 'logs': {'loss': 0.09952779114246368, 'accuracy': 0.9700000286102295, 'val_loss': 0.5298805832862854, 'val_accuracy': 0.8100000023841858}}]\n",
       "\n",
       "By ModelStep, set of supplied keys and number of records:\n",
-      "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 200, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 200, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step logs dataset_size loss accuracy val_loss val_accuracy': 5})\n"
+      "Counter({'<ModelStep.ON_PREDICT_BATCH_BEGIN: 340> utcnow model_step batch logs': 864, '<ModelStep.ON_PREDICT_BATCH_END: 345> utcnow model_step batch logs outputs': 864, '<ModelStep.ON_TEST_BATCH_BEGIN: 240> utcnow model_step batch logs': 200, '<ModelStep.ON_TEST_BATCH_END: 245> utcnow model_step batch logs loss accuracy': 200, '<ModelStep.ON_TRAIN_BATCH_BEGIN: 140> utcnow model_step batch logs': 120, '<ModelStep.ON_TRAIN_BATCH_END: 145> utcnow model_step batch logs loss accuracy': 120, '<ModelStep.ON_TRAIN_EPOCH_BEGIN: 120> utcnow model_step epoch logs': 50, '<ModelStep.ON_TEST_BEGIN: 200> utcnow model_step logs': 50, '<ModelStep.ON_TEST_END: 205> utcnow model_step logs loss accuracy': 50, '<ModelStep.ON_TRAIN_EPOCH_END: 125> utcnow model_step epoch logs loss accuracy val_loss val_accuracy': 50, '<ModelStep.ON_PREDICT_BEGIN: 300> utcnow model_step logs': 6, '<ModelStep.ON_PREDICT_END: 305> utcnow model_step logs': 6, '<ModelStep.ON_TRAIN_BEGIN: 100> utcnow model_step training_size logs': 5, '<ModelStep.ON_TRAIN_END: 105> utcnow model_step training_size logs loss accuracy val_loss val_accuracy': 5})\n"
      ]
     }
    ],
@@ -333,6 +341,26 @@
     "        ]\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ae2c7acc-a594-428b-a86c-a713b42c4bf9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Log written to disk\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Write the log\n",
+    "my_strategy_handler.write_train_log_for_tensorboard()\n",
+    "print(\"Log written to disk\")"
    ]
   },
   {

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -23,6 +23,7 @@ def test_imports():
     import h5py as h5
     import numpy as np
     import os
+    import random
     import re
     import tensorflow as tf
     import torch
@@ -130,6 +131,7 @@ def test_handler_combinations():
     import al_bench as alb
     import datetime
     import os
+    import random
     import re
 
     # Specify some testing parameters
@@ -186,7 +188,10 @@ def test_handler_combinations():
                 my_dataset_handler.set_all_label_definitions(my_label_definitions)
                 my_dataset_handler.set_all_labels(my_labels)
                 my_dataset_handler.set_validation_indices(
-                    list(range(my_feature_vectors.shape[0] // 10))
+                    random.sample(
+                        range(my_feature_vectors.shape[0]),
+                        my_feature_vectors.shape[0] // 10,
+                    )
                 )
 
                 my_model = model_creator(**parameters)

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -232,6 +232,7 @@ def test_handler_combinations():
                         ]
                     )
                 )
+                my_strategy_handler.write_epoch_log_to_tensorboard_file()
 
 
 def create_dataset(

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -257,7 +257,7 @@ def test_handler_combinations():
                         ]
                     )
                 )
-                my_strategy_handler.write_epoch_log_to_tensorboard_file(
+                my_strategy_handler.write_train_log_to_tensorboard_file(
                     log_dir=os.path.join("runs", combination_name)
                 )
 

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -141,29 +141,29 @@ def test_handler_combinations():
         number_of_categories_by_label=[4],
         label_to_test=0,
     )
-    number_iterations = 20
-    number_per_iteration = 5
+    number_iterations = 10
+    number_per_iteration = 10
 
     combination_index = 0
     for dataset_creator, DatasetHandler in (
-        (
-            create_dataset,
-            alb.dataset.GenericDatasetHandler,
-        ),
+        # (
+        #     create_dataset,
+        #     alb.dataset.GenericDatasetHandler,
+        # ),
         (
             create_dataset_4598_1280_4,
             alb.dataset.GenericDatasetHandler,
         ),
     ):
         for model_creator, ModelHandler in (
-            (
-                create_toy_tensorflow_model,
-                alb.model.TensorFlowModelHandler,
-            ),
-            (
-                create_toy_pytorch_model,
-                alb.model.PyTorchModelHandler,
-            ),
+            # (
+            #     create_toy_tensorflow_model,
+            #     alb.model.TensorFlowModelHandler,
+            # ),
+            # (
+            #     create_toy_pytorch_model,
+            #     alb.model.PyTorchModelHandler,
+            # ),
             (
                 create_tensorflow_model_with_dropout,
                 alb.model.TensorFlowModelHandler,
@@ -213,10 +213,10 @@ def test_handler_combinations():
                 # Go!
                 combination_name = "-".join(
                     [
-                        re.search(
-                            r"<class 'al_bench\.dataset\.(.*)'>",
-                            f"{type(my_dataset_handler)}",
-                        ).group(1),
+                        # re.search(
+                        #     r"<class 'al_bench\.dataset\.(.*)'>",
+                        #     f"{type(my_dataset_handler)}",
+                        # ).group(1),
                         re.search(
                             r"<class 'al_bench\.model\.(.*)'>",
                             f"{type(my_model_handler)}",

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -257,7 +257,7 @@ def test_handler_combinations():
                         ]
                     )
                 )
-                my_strategy_handler.write_train_log_to_tensorboard_file(
+                my_strategy_handler.write_train_log_for_tensorboard(
                     log_dir=os.path.join("runs", combination_name)
                 )
 


### PR DESCRIPTION
Loss, accuracy, validation loss, and validation accuracy from `GenericModelHandler.CustomCallback.log` entries for `ON_TRAIN_END` events are written to a directory of files for use with `TensorBoard`.  This allows comparison of the training outcomes each time additional labels are used in active learning.

The interface to the new `write_train_log_for_tensorboard` method exactly matches the interface to [`torch.utils.tensorboard.SummaryWriter`](https://pytorch.org/docs/stable/tensorboard.html).  The written files can be used within `TensorBoard` with `tensorboard --logdir=runs`, where `runs` is the default name of the directory used by `SummaryWriter` and hence by `write_train_log_for_tensorboard`.

This pull request also implements `write_epoch_log_for_tensorboard`, which writes entries for `ON_TRAIN_EPOCH_END` events.  It is for situations where a single training is being examined for it changes from epoch to epoch.