### PR TITLE
STYLE: Say "query" for interaction with oracle / clinician

### DIFF
--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -156,8 +156,8 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         # These parameters must be supplied to the set_learning_parameters call.
         self.required_parameters_keys = [
             "label_of_interest",
-            "maximum_iterations",
-            "number_to_select_per_iteration",
+            "maximum_queries",
+            "number_to_select_per_query",
         ]
         # This the exhaustive list of parameters that are valid when used with a
         # set_learning_parameters call.
@@ -320,10 +320,10 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             else [validation_feature_vectors, validation_labels]
         )
 
-        maximum_iterations = self.parameters["maximum_iterations"]
+        maximum_queries = self.parameters["maximum_queries"]
         label_of_interest = self.parameters["label_of_interest"]
 
-        for iteration in range(maximum_iterations):
+        for query in range(maximum_queries):
             print(f"Predicting for {feature_vectors.shape[0]} examples")
             self.predictions = self.model_handler.predict(feature_vectors)
             next_examples = self.select_next_examples(
@@ -352,14 +352,15 @@ class RandomStrategyHandler(GenericStrategyHandler):
     def select_next_examples(self, currently_labeled_examples, validation_indices=None):
         """
         Select new examples to be labeled by the expert.
-        `number_to_select_per_iteration` is the number that should be selected with each
-        iteration of the active learning strategy.  `currently_labeled_examples` is the
-        list of examples indices that have already been labeled.  `feature_vectors` is
-        the feature vector for each example in the entire set of examples, including
-        both those examples that have been labeled and those that could be selected for
-        labeling.
+        `number_to_select_per_query` is the number that should be selected with each
+          query of the active learning strategy.
+        `currently_labeled_examples` is the list of examples indices that have already
+          been labeled.
+        `feature_vectors` is the feature vector for each example in the entire set of
+          examples, including both those examples that have been labeled and those that
+          could be selected for labeling.
         """
-        number_to_select = self.parameters["number_to_select_per_iteration"]
+        number_to_select = self.parameters["number_to_select_per_query"]
         feature_vectors = self.dataset_handler.get_all_feature_vectors()
 
         # Make sure the pool to select from is large enough
@@ -399,7 +400,7 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest maximum score.
         """
-        number_to_select = self.parameters["number_to_select_per_iteration"]
+        number_to_select = self.parameters["number_to_select_per_query"]
         number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
@@ -441,7 +442,7 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest gap between highest and second-highest score.
         """
-        number_to_select = self.parameters["number_to_select_per_iteration"]
+        number_to_select = self.parameters["number_to_select_per_query"]
         number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
@@ -488,7 +489,7 @@ class EntropyStrategyHandler(GenericStrategyHandler):
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the highest entropy.
         """
-        number_to_select = self.parameters["number_to_select_per_iteration"]
+        number_to_select = self.parameters["number_to_select_per_query"]
         number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -233,8 +233,8 @@
     "my_strategy_handler.set_model_handler(my_model_handler)\n",
     "my_strategy_handler.set_learning_parameters(\n",
     "    label_of_interest=0,  # We've supplied only one label per feature vector\n",
-    "    maximum_iterations=5,\n",
-    "    number_to_select_per_iteration=20,\n",
+    "    maximum_queries=5,\n",
+    "    number_to_select_per_query=20,\n",
     ")"
    ]
   },
@@ -376,7 +376,7 @@
    ],
    "source": [
     "# Write the log\n",
-    "my_strategy_handler.write_train_log_for_tensorboard() # defaults to `runs` directory\n",
+    "my_strategy_handler.write_train_log_for_tensorboard()  # defaults to `runs` directory\n",
     "print(\"Log written to disk\")\n",
     "# Examine with `tensorboard --logidr runs`"
    ]

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -97,14 +97,7 @@ def deeply_numeric(x):
     import numpy as np
 
     return (
-        isinstance(
-            x,
-            (
-                int,
-                float,
-                np.float32,
-            ),
-        )
+        isinstance(x, (int, float, np.float32))
         or (isinstance(x, np.ndarray) and len(x.shape) == 0 and deeply_numeric(x[()]))
         or all([deeply_numeric(e) for e in x])
     )
@@ -141,8 +134,8 @@ def test_handler_combinations():
         number_of_categories_by_label=[4],
         label_to_test=0,
     )
-    number_iterations = 10
-    number_per_iteration = 10
+    number_queries = 10
+    number_per_query = 10
 
     combination_index = 0
     for dataset_creator, DatasetHandler in (
@@ -150,10 +143,7 @@ def test_handler_combinations():
         #     create_dataset,
         #     alb.dataset.GenericDatasetHandler,
         # ),
-        (
-            create_dataset_4598_1280_4,
-            alb.dataset.GenericDatasetHandler,
-        ),
+        (create_dataset_4598_1280_4, alb.dataset.GenericDatasetHandler),
     ):
         for model_creator, ModelHandler in (
             # (
@@ -164,14 +154,8 @@ def test_handler_combinations():
             #     create_toy_pytorch_model,
             #     alb.model.PyTorchModelHandler,
             # ),
-            (
-                create_tensorflow_model_with_dropout,
-                alb.model.TensorFlowModelHandler,
-            ),
-            (
-                create_pytorch_model_with_dropout,
-                alb.model.PyTorchModelHandler,
-            ),
+            (create_tensorflow_model_with_dropout, alb.model.TensorFlowModelHandler),
+            (create_pytorch_model_with_dropout, alb.model.PyTorchModelHandler),
         ):
             for StrategyHandler in (
                 alb.strategy.RandomStrategyHandler,
@@ -202,9 +186,9 @@ def test_handler_combinations():
                 my_strategy_handler.set_dataset_handler(my_dataset_handler)
                 my_strategy_handler.set_model_handler(my_model_handler)
                 my_strategy_handler.set_learning_parameters(
-                    maximum_iterations=number_iterations,
+                    maximum_queries=number_queries,
                     label_of_interest=parameters["label_to_test"],
-                    number_to_select_per_iteration=number_per_iteration,
+                    number_to_select_per_query=number_per_query,
                 )
 
                 # Start with nothing labeled yet
@@ -268,10 +252,7 @@ def test_handler_combinations():
 
 
 def create_dataset(
-    number_of_superpixels,
-    number_of_features,
-    number_of_categories_by_label,
-    **kwargs,
+    number_of_superpixels, number_of_features, number_of_categories_by_label, **kwargs
 ):
     """
     Create a toy set of feature vectors
@@ -323,10 +304,7 @@ def create_dataset(
 
 
 def create_dataset_4598_1280_4(
-    number_of_superpixels,
-    number_of_features,
-    number_of_categories_by_label,
-    **kwargs,
+    number_of_superpixels, number_of_features, number_of_categories_by_label, **kwargs
 ):
     import h5py as h5
     import numpy as np


### PR DESCRIPTION
The previous word "iteration" could generically refer to all sorts of different concepts.  Instead, use "query" for an interaction with an oracle / clinician that retrieves the true label values for a set of examples.

FWIW, similar language is used with databases, where an (SQL) query might be used to retrieve information from an (Oracle) database.