### PR TITLE
Record confidence

### DIFF
--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -19,6 +19,7 @@
 from datetime import datetime
 import enum
 import numpy as np
+import scipy.stats
 from . import dataset
 
 
@@ -129,6 +130,11 @@ class GenericModelHandler(AbstractModelHandler):
     def write_epoch_log_for_tensorboard(self, *args, **kwargs):
         return self.custom_callback.write_epoch_log_for_tensorboard(*args, **kwargs)
 
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs):
+        return self.custom_callback.write_confidence_log_for_tensorboard(
+            *args, **kwargs
+        )
+
     def set_dataset_handler(self, dataset_handler):
         if not isinstance(dataset_handler, dataset.AbstractDatasetHandler):
             raise ValueError(
@@ -168,29 +174,34 @@ class GenericModelHandler(AbstractModelHandler):
 
             if self.log is None:
                 return False
+            beginning = datetime.utcfromtimestamp(0)
             with SummaryWriter(*args, **kwargs) as writer:
-                beginning = datetime.utcfromtimestamp(0)
                 for entry in self.log:
-                    if entry["model_step"] not in model_steps:
-                        continue
                     logs = entry["logs"]
-                    if logs is None:
+                    if entry["model_step"] not in model_steps or logs is None:
                         continue
                     utc_seconds = (entry["utcnow"] - beginning).total_seconds()
                     x_value = entry[x_key]
-                    for key in y_dictionary:
-                        if key in logs:
-                            y_value = logs[key]
-                            # print(
-                            #     f"Invoking writer.add_scalar({y_dictionary[key]}, {y_value}, {x_value}, walltime={utc_seconds}, new_style=True)"
-                            # )
-                            writer.add_scalar(
-                                y_dictionary[key],
-                                y_value,
-                                x_value,
-                                walltime=utc_seconds,
-                                new_style=True,
-                            )
+                    for key in logs.keys() & y_dictionary.keys():
+                        name = y_dictionary[key]
+                        y_value = logs[key]
+                        """
+                        print(
+                            "Invoking writer.add_scalar("
+                            f"tag={repr(name)}, "
+                            f"scalar_value={repr(y_value)}, "
+                            f"global_step={repr(x_value)}, "
+                            f"walltime={repr(utc_seconds)}, "
+                            "new_style=True)"
+                        )
+                        """
+                        writer.add_scalar(
+                            tag=name,
+                            scalar_value=y_value,
+                            global_step=x_value,
+                            walltime=utc_seconds,
+                            new_style=True,
+                        )
             return True
 
         def write_train_log_for_tensorboard(self, *args, **kwargs):
@@ -219,11 +230,104 @@ class GenericModelHandler(AbstractModelHandler):
                 model_steps, y_dictionary, x_key, *args, **kwargs
             )
 
+        def write_confidence_log_for_tensorboard(self, *args, **kwargs):
+            if self.log is None:
+                return False
+            x_key = "training_size"
+            beginning = datetime.utcfromtimestamp(0)
+            predictions_list = list()
+
+            from torch.utils.tensorboard import SummaryWriter
+
+            with SummaryWriter(*args, **kwargs) as writer:
+                for entry in self.log:
+                    model_step = entry["model_step"]
+
+                    if model_step == ModelStep.ON_PREDICT_BEGIN:
+                        # Clear accumulated records
+                        predictions_list = list()
+
+                    if model_step in (
+                        ModelStep.ON_PREDICT_BATCH_END,
+                        ModelStep.ON_PREDICT_END,
+                    ):
+                        # Accumulate any records
+                        if (
+                            entry.get("logs") is not None
+                            and entry.get("logs").get("outputs") is not None
+                        ):
+                            predictions_list.append(entry["logs"]["outputs"])
+
+                    if model_step == ModelStep.ON_PREDICT_END:
+                        # Compute and write out statics from accumulated predictions
+                        if len(predictions_list) == 0:
+                            continue
+
+                        # Combine predictions into one giant numpy array
+                        number_of_predictions = sum(
+                            (predict.shape[0] for predict in predictions_list)
+                        )
+                        predictions = np.empty(
+                            (number_of_predictions, predictions_list[0].shape[1])
+                        )
+                        current_index = 0
+                        for predict in predictions_list:
+                            assert isinstance(predict, np.ndarray)
+                            assert len(predict.shape) == 2
+                            assert predict.shape[1] == predictions_list[0].shape[1]
+                            next_index = current_index + predict.shape[0]
+                            predictions[current_index:next_index, :] = predict
+                            current_index = next_index
+                        predictions_list = list()
+
+                        # Compute several scores for each prediction.  High scores
+                        # correspond to high confidence.
+                        entropy_score = -scipy.stats.entropy(predictions, axis=-1)
+                        prediction_indices = np.arange(len(predictions))
+                        margin_argsort = np.argsort(predictions, axis=-1)
+                        confidence_score = predictions[
+                            prediction_indices, margin_argsort[:, -1]
+                        ]
+                        margin_score = (
+                            confidence_score
+                            - predictions[prediction_indices, margin_argsort[:, -2]]
+                        )
+
+                        # Report median scores
+                        x_value = entry[x_key]
+                        utc_seconds = (entry["utcnow"] - beginning).total_seconds()
+                        for statistic_kind, source in zip(
+                            ("maximum", "margin", "entropy"),
+                            (confidence_score, margin_score, entropy_score),
+                        ):
+                            percentiles = (5, 10, 25, 50)
+                            y_values = np.percentile(source, percentiles)
+                            for percentile, y_value in zip(percentiles, y_values):
+                                name = f"Confidence/{statistic_kind}/{percentile:02d}%"
+                                """
+                                print(
+                                    "Invoking writer.add_scalar("
+                                    f"tag={repr(name)}, "
+                                    f"scalar_value={repr(y_value)}, "
+                                    f"global_step={repr(x_value)}, "
+                                    f"walltime={repr(utc_seconds)}, "
+                                    "new_style=True)"
+                                )
+                                """
+                                writer.add_scalar(
+                                    tag=name,
+                                    scalar_value=y_value,
+                                    global_step=x_value,
+                                    walltime=utc_seconds,
+                                    new_style=True,
+                                )
+            return True
+
+        # Because tensorflow defines the interface for on_train_begin, etc. for us and
+        # invokes it for us, we cannot simply supply training_size through this
+        # interface.  Instead we grab it from self.training_size and require that the
+        # user has already set that to something reasonable.
         def on_train_begin(self, logs=None):
-            # Because tensorflow defines the interface for on_train_begin for us and
-            # invokes it for us, we cannot simply supply training_size through this
-            # interface.  Instead we grab it from self.training_size and require that
-            # the user has already set that to something reasonable.
             self.log.append(
                 dict(
                     utcnow=datetime.utcnow(),
@@ -234,10 +338,6 @@ class GenericModelHandler(AbstractModelHandler):
             )
 
         def on_train_end(self, logs=None):
-            # Because tensorflow defines the interface for on_train_end for us and
-            # invokes it for us, we cannot simply supply training_size through this
-            # interface.  Instead we grab it from self.training_size and require that
-            # the user has already set that to something reasonable.
             self.log.append(
                 dict(
                     utcnow=datetime.utcnow(),
@@ -252,6 +352,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TRAIN_EPOCH_BEGIN,
+                    training_size=self.training_size,
                     epoch=epoch,
                     logs=logs,
                 )
@@ -262,6 +363,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TRAIN_EPOCH_END,
+                    training_size=self.training_size,
                     epoch=epoch,
                     logs=logs,
                 )
@@ -272,6 +374,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TRAIN_BATCH_BEGIN,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )
@@ -283,6 +386,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TRAIN_BATCH_END,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )
@@ -293,6 +397,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TEST_BEGIN,
+                    training_size=self.training_size,
                     logs=logs,
                 )
             )
@@ -302,6 +407,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TEST_END,
+                    training_size=self.training_size,
                     logs=logs,
                 )
             )
@@ -311,6 +417,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TEST_BATCH_BEGIN,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )
@@ -321,6 +428,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_TEST_BATCH_END,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )
@@ -331,6 +439,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_PREDICT_BEGIN,
+                    training_size=self.training_size,
                     logs=logs,
                 )
             )
@@ -340,6 +449,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_PREDICT_END,
+                    training_size=self.training_size,
                     logs=logs,
                 )
             )
@@ -349,6 +459,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_PREDICT_BATCH_BEGIN,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )
@@ -360,6 +471,7 @@ class GenericModelHandler(AbstractModelHandler):
                 dict(
                     utcnow=datetime.utcnow(),
                     model_step=ModelStep.ON_PREDICT_BATCH_END,
+                    training_size=self.training_size,
                     batch=batch,
                     logs=logs,
                 )

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -295,6 +295,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def write_epoch_log_for_tensorboard(self, *args, **kwargs):
         return self.model_handler.write_epoch_log_for_tensorboard(*args, **kwargs)
 
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs):
+        return self.model_handler.write_confidence_log_for_tensorboard(*args, **kwargs)
+
     def run(self, currently_labeled_examples):
         """
         Run the strategy, start to finish.
@@ -332,12 +335,10 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             currently_labeled_examples = currently_labeled_examples.union(next_examples)
             current_indices = tuple(currently_labeled_examples)
             current_feature_vectors = feature_vectors[current_indices, :]
-            current_labels = labels[current_indices, :]
+            current_labels = labels[current_indices, label_of_interest]
             print(f"Training with {current_feature_vectors.shape[0]} examples")
             self.model_handler.train(
-                current_feature_vectors,
-                current_labels[:, label_of_interest],
-                *validation_args,
+                current_feature_vectors, current_labels, *validation_args
             )
 
         print(f"Predicting for {feature_vectors.shape[0]} examples")

--- a/test/test_high_level.py
+++ b/test/test_high_level.py
@@ -249,6 +249,9 @@ def test_handler_combinations():
                 my_strategy_handler.write_train_log_for_tensorboard(
                     log_dir=os.path.join("runs", combination_name)
                 )
+                my_strategy_handler.write_confidence_log_for_tensorboard(
+                    log_dir=os.path.join("runs", combination_name)
+                )
 
 
 def create_dataset(


### PR DESCRIPTION
Compute confidence (softmax), margin (between top two alternatives), and (negative) entropy for every prediction, each time we train with additional labeled samples.  Each time report on the 5%-, 10%-, 25%-, and 50%-tile values for these three statistics.  Make these available to TensorBoard via `write_confidence_log_for_tensorboard`.

To see these confidence statistics graphically, run
```shell
cd ALBench
python test/test_high_level.py
tensorboard --logdir test/runs
```
... and point your web browser to [http://localhost:6006/](http://localhost:6006/).  The graphed lines in the "Confidence" section show a general trend upward indicating that the median (and also the other percentiles) confidence level gets better as the number of labeled samples used in training grows.  (Looking at it another way, the number of samples that achieve any fixed confidence level grows as the number of labeled samples used in training grows.)  As a sanity check, note that the higher-percentile statistics climb earlier than the lower-percentile statistics. 