### PR TITLE
ENH: Implement `GenericModelHandler.compute_confidence_statistics`

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -558,9 +558,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             or label_definitions_width == 0  # nothing to compare
             or (
                 len(self.labels.shape) == 1  # 1-dimensional numpy array
-                and len(
-                    set(self.labels).difference(set(self.label_definitions[0]))
-                )
+                and len(set(self.labels).difference(set(self.label_definitions[0])))
                 == 0
             )
             or (


### PR DESCRIPTION
Add a `compute_confidence_statistics(predictions, percentiles)` method to the `GenericModelHandler` class, to compute confidence values for the supplied prediction vectors and return the specified percentile values for each statistic.

More precisely, for each of `"maximum"` (a.k.a softmax), `"margin"` (a.k.a. difference of score of the prediction and the runner up), and `"entropy"` (which is negated so that higher values represent higher confidence, like the other confidence values) we now compute the 5-, 10-, 25-, and 50-percentile value in the supplied set of predictions, and return them as a multi-level dictionary (e.g., `response["maximum"][50] == 0.90`).  The implementation of `write_confidence_log_for_tensorboard` now calls `compute_confidence_statistics` to do this computation before writing out the values to a Tensorboard log directory.

The class known as  `model.GenericModelHandler.CustomCallback` is now relocated architecturally and renamed to be `model.Logger`, to reflect its purpose and that its purpose exists outside of the `model.GenericModelHandler` context.  The `model.Logger` class constructor now requires a `model_handler` value as a parameter.