### PR TITLE
ENH: Log predictions and compute confidence for unlabeled examples only

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -290,9 +290,8 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             if self.validation_indices is None
             else self.get_some_feature_vectors(
                 list(
-                    set(range(self.feature_vectors.shape[0])).difference(
-                        set(self.validation_indices)
-                    )
+                    set(range(self.feature_vectors.shape[0]))
+                    - set(self.validation_indices)
                 )
             )
         )
@@ -375,11 +374,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             self.get_all_labels()
             if self.validation_indices is None
             else self.get_some_labels(
-                list(
-                    set(range(self.labels.shape[0])).difference(
-                        set(self.validation_indices)
-                    )
-                )
+                list(set(range(self.labels.shape[0])) - set(self.validation_indices))
             )
         )
 
@@ -558,18 +553,13 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             or label_definitions_width == 0  # nothing to compare
             or (
                 len(self.labels.shape) == 1  # 1-dimensional numpy array
-                and len(set(self.labels).difference(set(self.label_definitions[0])))
-                == 0
+                and len(set(self.labels) - set(self.label_definitions[0])) == 0
             )
             or (
                 len(self.labels.shape) == 2  # 2-dimensional numpy array
                 and all(
                     [
-                        len(
-                            set(self.labels[:, col]).difference(
-                                set(self.label_definitions[col])
-                            )
-                        )
+                        len(set(self.labels[:, col]) - set(self.label_definitions[col]))
                         == 0
                         for col in range(self.labels.shape[1])
                     ]

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -102,12 +102,12 @@ class Logger(keras.callbacks.Callback):
 
     def write_train_log_for_tensorboard(self, *args, **kwargs):
         model_steps = (ModelStep.ON_TRAIN_END,)
-        y_dictionary = dict(
-            loss="Loss/train",
-            val_loss="Loss/validation",
-            accuracy="Accuracy/train",
-            val_accuracy="Accuracy/validation",
-        )
+        y_dictionary = {
+            "loss": "Loss/train",
+            "val_loss": "Loss/validation",
+            "accuracy": "Accuracy/train",
+            "val_accuracy": "Accuracy/validation",
+        }
         x_key = "training_size"
         return self.write_some_log_for_tensorboard(
             model_steps, y_dictionary, x_key, *args, **kwargs
@@ -115,12 +115,12 @@ class Logger(keras.callbacks.Callback):
 
     def write_epoch_log_for_tensorboard(self, *args, **kwargs):
         model_steps = (ModelStep.ON_TRAIN_EPOCH_END,)
-        y_dictionary = dict(
-            loss="Loss/train",
-            val_loss="Loss/test",
-            accuracy="Accuracy/train",
-            val_accuracy="Accuracy/test",
-        )
+        y_dictionary = {
+            "loss": "Loss/train",
+            "val_loss": "Loss/test",
+            "accuracy": "Accuracy/train",
+            "val_accuracy": "Accuracy/test",
+        }
         x_key = "epoch"
         return self.write_some_log_for_tensorboard(
             model_steps, y_dictionary, x_key, *args, **kwargs
@@ -196,152 +196,152 @@ class Logger(keras.callbacks.Callback):
     # user has already set that to something reasonable.
     def on_train_begin(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_BEGIN,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_BEGIN,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_train_end(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_END,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_END,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_epoch_begin(self, epoch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_EPOCH_BEGIN,
-                training_size=self.training_size,
-                epoch=epoch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_EPOCH_BEGIN,
+                "training_size": self.training_size,
+                "epoch": epoch,
+                "logs": logs,
+            }
         )
 
     def on_epoch_end(self, epoch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_EPOCH_END,
-                training_size=self.training_size,
-                epoch=epoch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_EPOCH_END,
+                "training_size": self.training_size,
+                "epoch": epoch,
+                "logs": logs,
+            }
         )
 
     def on_train_batch_begin(self, batch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_BATCH_BEGIN,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_BATCH_BEGIN,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
     def on_train_batch_end(self, batch, logs=None):
         # For tensorflow, logs.keys() == ["loss", "accuracy"]
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TRAIN_BATCH_END,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TRAIN_BATCH_END,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
     def on_test_begin(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TEST_BEGIN,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TEST_BEGIN,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_test_end(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TEST_END,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TEST_END,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_test_batch_begin(self, batch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TEST_BATCH_BEGIN,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TEST_BATCH_BEGIN,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
     def on_test_batch_end(self, batch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_TEST_BATCH_END,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_TEST_BATCH_END,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
     def on_predict_begin(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_PREDICT_BEGIN,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_PREDICT_BEGIN,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_predict_end(self, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_PREDICT_END,
-                training_size=self.training_size,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_PREDICT_END,
+                "training_size": self.training_size,
+                "logs": logs,
+            }
         )
 
     def on_predict_batch_begin(self, batch, logs=None):
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_PREDICT_BATCH_BEGIN,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_PREDICT_BATCH_BEGIN,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
     def on_predict_batch_end(self, batch, logs=None):
         # For tensorflow, logs.keys() == ["outputs"]
         self.log.append(
-            dict(
-                utcnow=datetime.utcnow(),
-                model_step=ModelStep.ON_PREDICT_BATCH_END,
-                training_size=self.training_size,
-                batch=batch,
-                logs=logs,
-            )
+            {
+                "utcnow": datetime.utcnow(),
+                "model_step": ModelStep.ON_PREDICT_BATCH_END,
+                "training_size": self.training_size,
+                "batch": batch,
+                "logs": logs,
+            }
         )
 
 
@@ -386,7 +386,7 @@ class AbstractModelHandler:
             "Abstract method AbstractModelHandler::train should not be called."
         )
 
-    def predict(self, features):
+    def predict(self, features, log_it):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -519,7 +519,7 @@ class TensorFlowModelHandler(GenericModelHandler):
         validation_args = (
             dict()
             if validation_features is None
-            else dict(validation_data=(validation_features, validation_labels))
+            else {"validation_data": (validation_features, validation_labels)}
         )
         # Get `epochs` from training parameters!!!
         self.logger.training_size = train_features.shape[0]
@@ -533,14 +533,19 @@ class TensorFlowModelHandler(GenericModelHandler):
         )
         # print(f"{repr(self.logger.get_log()) = }")
 
-    def predict(self, features):
+    def predict(self, features, log_it):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
         Parameters include which examples should be predicted.
         """
 
-        predictions = self.model.predict(features, verbose=0, callbacks=[self.logger])
+        if log_it:
+            predictions = self.model.predict(
+                features, verbose=0, callbacks=[self.logger]
+            )
+        else:
+            predictions = self.model.predict(features, verbose=0)
         # print(f"{repr(self.logger.get_log()) = }")
         return predictions
 
@@ -674,13 +679,13 @@ class PyTorchModelHandler(GenericModelHandler):
                 accuracy = (new_correct / new_size).detach().cpu().numpy()
                 if not isinstance(accuracy, (int, float, np.float32, np.float64)):
                     accuracy = accuracy[()]
-                logs = dict(loss=loss, accuracy=accuracy)
+                logs = {"loss": loss, "accuracy": accuracy}
                 self.logger.on_train_batch_end(i, logs)
             loss = train_loss / train_size
             accuracy = (train_correct / train_size).detach().cpu().numpy()
             if not isinstance(accuracy, (int, float, np.float32, np.float64)):
                 accuracy = accuracy[()]
-            logs = dict(loss=loss, accuracy=accuracy)
+            logs = {"loss": loss, "accuracy": accuracy}
             if do_validation:
                 validation_loss = 0.0
                 validation_size = 0
@@ -699,13 +704,13 @@ class PyTorchModelHandler(GenericModelHandler):
                 val_accuracy = (
                     (validation_correct / validation_size).detach().cpu().numpy()[()]
                 )
-                more_logs = dict(val_loss=val_loss, val_accuracy=val_accuracy)
+                more_logs = {"val_loss": val_loss, "val_accuracy": val_accuracy}
                 logs = {**logs, **more_logs}
             self.logger.on_epoch_end(epoch, logs)
 
         self.logger.on_train_end(logs)  # `logs` is from the last epoch
 
-    def predict(self, features):
+    def predict(self, features, log_it):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -713,11 +718,12 @@ class PyTorchModelHandler(GenericModelHandler):
         """
         import torch
 
-        self.logger.on_predict_begin()
+        if log_it:
+            self.logger.on_predict_begin()
         predictions = self.model(torch.from_numpy(features))
         predictions = predictions.detach().cpu().numpy()
-        logs = dict(outputs=predictions)
-        self.logger.on_predict_end(logs)
+        if log_it:
+            self.logger.on_predict_end({"outputs": predictions})
         return predictions
 
 
@@ -761,7 +767,7 @@ class AbstractEnsembleModelHandler(GenericModelHandler):
         """
         raise NotImplementedError("Not implemented")
 
-    def predict(self, features):
+    def predict(self, features, log_it):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -810,7 +816,7 @@ class ExampleEnsembleModelHandler(AbstractEnsembleModelHandler):
         """
         raise NotImplementedError("Not implemented")
 
-    def predict(self, features):
+    def predict(self, features, log_it):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -24,12 +24,12 @@ def test_0010_dataset_handler_interface():
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = dict(
-        number_of_superpixels=1000,
-        number_of_features=2048,
-        number_of_categories_by_label=[5, 7],
-        label_to_test=0,
-    )
+    parameters = {
+        "number_of_superpixels": 1000,
+        "number_of_features": 2048,
+        "number_of_categories_by_label": [5, 7],
+        "label_to_test": 0,
+    }
 
     # Try trivial exercises on the handler interface
     for DatasetHandler in (alb.dataset.GenericDatasetHandler,):

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -24,12 +24,12 @@ def test_0020_model_handler_interface():
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = dict(
-        number_of_superpixels=1000,
-        number_of_features=2048,
-        number_of_categories_by_label=[5, 7],
-        label_to_test=0,
-    )
+    parameters = {
+        "number_of_superpixels": 1000,
+        "number_of_features": 2048,
+        "number_of_categories_by_label": [5, 7],
+        "label_to_test": 0,
+    }
 
     # Try trivial exercises on the handler interface
     for ModelHandler in (

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -24,12 +24,12 @@ def test_0030_strategy_handler_interfac():
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = dict(
-        number_of_superpixels=1000,
-        number_of_features=2048,
-        number_of_categories_by_label=[5, 7],
-        label_to_test=0,
-    )
+    parameters = {
+        "number_of_superpixels": 1000,
+        "number_of_features": 2048,
+        "number_of_categories_by_label": [5, 7],
+        "label_to_test": 0,
+    }
 
     # Try trivial exercises on the handler interface
     for StrategyHandler in (

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -46,12 +46,12 @@ def test_0100_handler_combinations():
     """
 
     # Specify some testing parameters
-    parameters = dict(
-        number_of_superpixels=4598,
-        number_of_features=1280,
-        number_of_categories_by_label=[4],
-        label_to_test=0,
-    )
+    parameters = {
+        "number_of_superpixels": 4598,
+        "number_of_features": 1280,
+        "number_of_categories_by_label": [4],
+        "label_to_test": 0,
+    }
     number_queries = 10
     number_per_query = 10
 


### PR DESCRIPTION
Henceforth the percentile statistics for each confidence metric will be taken from the universe of all predictions for _unlabeled_ examples only.  Predictions for labeled examples, whether or not they are correct or confident, will not be included in the pool from which the percentiles are calculated.

Also, miscellaneous changes:
STYLE: Change `_examples` to `_indices` to clarify that it's not the feature vectors themselves
STYLE: Use `set - set` instead of `set.difference(set)`
STYLE: Use `set | set` instead of `set.union(set)`
STYLE: Use `{"a": "b"}` instead of `dict(a="b")`
STYLE: Shorten `currently_labeled_indices` to `labeled_indices`
STYLE: Use `excluded_indices` instead of re-purposing existing variable