### PR TITLE
COMP: Add Python type hints

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
         include:
           - flake8-python-git-tag: ""

--- a/al_bench/__init__.py
+++ b/al_bench/__init__.py
@@ -18,7 +18,9 @@
 
 """Active Learning Benchmarking tool"""
 
-__version__ = "0.0.1"
+from __future__ import annotations
+
+__version__: str = "0.0.1"
 
 """
 

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -16,8 +16,11 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import h5py as h5
 import numpy as np
+from numpy.typing import NDArray
+from typing import Iterable, List, MutableMapping
 
 
 class AbstractDatasetHandler:
@@ -25,181 +28,197 @@ class AbstractDatasetHandler:
     Abstract base class for dataset handlers.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::__init__ should not be called."
         )
 
-    def read_all_feature_vectors_from_h5py(self, filename, data_name="features"):
+    def read_all_feature_vectors_from_h5py(
+        self, filename: str, data_name: str = "features"
+    ) -> None:
         raise NotImplementedError(
             "Abstract method "
             "AbstractDatasetHandler::read_all_feature_vectors_from_h5py should not be "
             "called."
         )
 
-    def write_all_feature_vectors_to_h5py(self, filename, data_name="features"):
+    def write_all_feature_vectors_to_h5py(
+        self, filename: str, data_name: str = "features"
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::write_all_feature_vectors_to_h5py "
             "should not be called."
         )
 
-    def set_all_feature_vectors(self, feature_vectors):
+    def set_all_feature_vectors(self, feature_vectors: NDArray) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_feature_vectors "
             "should not be called."
         )
 
-    def get_all_feature_vectors(self):
+    def get_all_feature_vectors(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_feature_vectors "
             "should not be called."
         )
 
-    def clear_all_feature_vectors(self):
+    def clear_all_feature_vectors(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::clear_all_feature_vectors "
             "should not be called."
         )
 
-    def set_some_feature_vectors(self, feature_vector_indices, feature_vectors):
+    def set_some_feature_vectors(
+        self, feature_vector_indices: NDArray, feature_vectors: NDArray
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_some_feature_vectors "
             "should not be called."
         )
 
-    def get_some_feature_vectors(self, feature_vector_indices):
+    def get_some_feature_vectors(self, feature_vector_indices: NDArray) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_some_feature_vectors "
             "should not be called."
         )
 
-    def get_training_feature_vectors(self):
+    def get_training_feature_vectors(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_training_feature_vectors "
             "should not be called."
         )
 
-    def get_validation_feature_vectors(self):
+    def get_validation_feature_vectors(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_validation_feature_vectors "
             "should not be called."
         )
 
-    def read_all_labels_from_h5py(self, filename, data_name="labels"):
+    def read_all_labels_from_h5py(
+        self, filename: str, data_name: str = "labels"
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::read_all_labels_from_h5py "
             "should not be called."
         )
 
-    def write_all_labels_to_h5py(self, filename, data_name="labels"):
+    def write_all_labels_to_h5py(
+        self, filename: str, data_name: str = "labels"
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::write_all_labels_to_h5py "
             "should not be called."
         )
 
-    def set_all_labels(self, labels):
+    def set_all_labels(self, labels: NDArray) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_labels "
             "should not be called."
         )
 
-    def get_all_labels(self):
+    def get_all_labels(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_labels "
             "should not be called."
         )
 
-    def clear_all_labels(self):
+    def clear_all_labels(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::clear_all_labels "
             "should not be called."
         )
 
-    def set_some_labels(self, label_indices, labels):
+    def set_some_labels(self, label_indices: NDArray, labels: NDArray) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_some_labels "
             "should not be called."
         )
 
-    def get_some_labels(self, label_indices):
+    def get_some_labels(self, label_indices: NDArray) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_some_labels "
             "should not be called."
         )
 
-    def get_training_labels(self):
+    def get_training_labels(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_training_labels "
             "should not be called."
         )
 
-    def get_validation_labels(self):
+    def get_validation_labels(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_validation_labels "
             "should not be called."
         )
 
-    def set_all_dictionaries(self, dictionaries):
+    def set_all_dictionaries(self, dictionaries: Iterable[MutableMapping]) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_dictionaries "
             "should not be called."
         )
 
-    def get_all_dictionaries(self):
+    def get_all_dictionaries(self) -> Iterable[MutableMapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_dictionaries "
             "should not be called."
         )
 
-    def clear_all_dictionaries(self):
+    def clear_all_dictionaries(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::clear_all_dictionaries "
             "should not be called."
         )
 
-    def set_some_dictionaries(self, dictionary_indices, dictionaries):
+    def set_some_dictionaries(
+        self, dictionary_indices: NDArray, dictionaries: Iterable[MutableMapping]
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_some_dictionaries "
             "should not be called."
         )
 
-    def get_some_dictionaries(self, dictionary_indices):
+    def get_some_dictionaries(
+        self, dictionary_indices: NDArray
+    ) -> Iterable[MutableMapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_some_dictionaries "
             "should not be called."
         )
 
-    def set_validation_indices(self, validation_indices):
+    def set_validation_indices(self, validation_indices: NDArray) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_validation_indices "
             "should not be called."
         )
 
-    def get_validation_indices(self):
+    def get_validation_indices(self) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_validation_indices "
             "should not be called."
         )
 
-    def clear_validation_indices(self):
+    def clear_validation_indices(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::clear_validation_indices "
             "should not be called."
         )
 
-    def set_all_label_definitions(self, label_definitions):
+    def set_all_label_definitions(
+        self, label_definitions: Iterable[MutableMapping]
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_label_definitions "
             "should not be called."
         )
 
-    def get_all_label_definitions(self):
+    def get_all_label_definitions(self) -> Iterable[MutableMapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_label_definitions "
             "should not be called."
         )
 
-    def check_data_consistency(self):
+    def check_data_consistency(self) -> bool:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::check_data_consistency "
             "should not be called."
@@ -209,24 +228,24 @@ class AbstractDatasetHandler:
 class GenericDatasetHandler(AbstractDatasetHandler):
     def __init__(self):
         # super(GenericDatasetHandler, self).__init__()
-        self.feature_vectors = None
-        self.labels = None
-        self.dictionaries = None
-        self.label_definitions = None
-        self.validation_indices = None
+        pass
 
     """
     Handle the vector of features for each stored entity.
     """
 
-    def read_all_feature_vectors_from_h5py(self, filename, data_name="features"):
+    def read_all_feature_vectors_from_h5py(
+        self, filename: str, data_name: str = "features"
+    ) -> None:
         """
         Read the entire database of features from a supplied h5py file.
         """
         with h5.File(filename) as ds:
-            self.feature_vectors = np.array(ds[data_name])
+            self.feature_vectors: NDArray = np.array(ds[data_name])
 
-    def write_all_feature_vectors_to_h5py(self, filename, data_name="features"):
+    def write_all_feature_vectors_to_h5py(
+        self, filename: str, data_name: str = "features"
+    ) -> None:
         """
         Write the entire database of features to a h5py file.
         """
@@ -235,7 +254,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
                 data_name, self.feature_vectors.shape, data=self.feature_vectors
             )
 
-    def set_all_feature_vectors(self, feature_vectors):
+    def set_all_feature_vectors(self, feature_vectors: NDArray) -> None:
         """
         Set the entire database of feature vectors from a supplied numpy array.
         """
@@ -247,19 +266,23 @@ class GenericDatasetHandler(AbstractDatasetHandler):
                 "ndarray."
             )
 
-    def get_all_feature_vectors(self):
+    def get_all_feature_vectors(self) -> NDArray:
         """
         Get the entire database of feature vectors as a numpy array.
         """
-        return self.feature_vectors
+        return (
+            self.feature_vectors if hasattr(self, "feature_vectors") else np.zeros(())
+        )
 
-    def clear_all_feature_vectors(self):
+    def clear_all_feature_vectors(self) -> None:
         """
         Remove all feature vectors from the database
         """
-        self.feature_vectors = None
+        del self.feature_vectors
 
-    def set_some_feature_vectors(self, feature_vector_indices, feature_vectors):
+    def set_some_feature_vectors(
+        self, feature_vector_indices: NDArray, feature_vectors: NDArray
+    ) -> None:
         """
         This overwrites existing feature vectors.  It does not (yet) handle insert,
         delete, or append.
@@ -272,7 +295,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         self.feature_vectors[feature_vector_indices] = feature_vectors
 
-    def get_some_feature_vectors(self, feature_vector_indices):
+    def get_some_feature_vectors(self, feature_vector_indices: NDArray) -> NDArray:
         """
         This fetches a subset of existing feature_vectors.
 
@@ -284,22 +307,24 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         return self.feature_vectors[feature_vector_indices]
 
-    def get_training_feature_vectors(self):
+    def get_training_feature_vectors(self) -> NDArray:
         return (
             self.get_all_feature_vectors()
-            if self.validation_indices is None
+            if not hasattr(self, "validation_indices")
             else self.get_some_feature_vectors(
-                list(
-                    set(range(self.feature_vectors.shape[0]))
-                    - set(self.validation_indices)
+                np.array(
+                    list(
+                        set(range(self.feature_vectors.shape[0]))
+                        - set(self.validation_indices)
+                    )
                 )
             )
         )
 
-    def get_validation_feature_vectors(self):
+    def get_validation_feature_vectors(self) -> NDArray:
         return (
-            None
-            if self.validation_indices is None
+            np.zeros(())
+            if not hasattr(self, "validation_indices")
             else self.get_some_feature_vectors(self.validation_indices)
         )
 
@@ -307,21 +332,25 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     Handle the label(s) for each stored entity.
     """
 
-    def read_all_labels_from_h5py(self, filename, data_name="labels"):
+    def read_all_labels_from_h5py(
+        self, filename: str, data_name: str = "labels"
+    ) -> None:
         """
         Read the entire database of labels from a supplied h5py file.
         """
         with h5.File(filename) as ds:
-            self.labels = np.array(ds[data_name])
+            self.labels: NDArray = np.array(ds[data_name])
 
-    def write_all_labels_to_h5py(self, filename, data_name="labels"):
+    def write_all_labels_to_h5py(
+        self, filename: str, data_name: str = "labels"
+    ) -> None:
         """
         Write the entire database of labels to a h5py file.
         """
         with h5.File(filename, "w") as f:
             f.create_dataset(data_name, self.labels.shape, data=self.labels)
 
-    def set_all_labels(self, labels):
+    def set_all_labels(self, labels: NDArray) -> None:
         """
         Set the entire database of labels from a supplied numpy array.
         """
@@ -333,19 +362,19 @@ class GenericDatasetHandler(AbstractDatasetHandler):
                 "2-dimensional numpy ndarray."
             )
 
-    def get_all_labels(self):
+    def get_all_labels(self) -> NDArray:
         """
         Get the entire database of labels as a numpy array.
         """
-        return self.labels
+        return self.labels if hasattr(self, "labels") else np.zeros(())
 
-    def clear_all_labels(self):
+    def clear_all_labels(self) -> None:
         """
         Remove all labels from the database
         """
-        self.labels = None
+        del self.labels
 
-    def set_some_labels(self, label_indices, labels):
+    def set_some_labels(self, label_indices: NDArray, labels: NDArray) -> None:
         """
         This overwrites existing labels.  It does not (yet) handle insert, delete, or
         append.
@@ -358,7 +387,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         self.labels[label_indices] = labels
 
-    def get_some_labels(self, label_indices):
+    def get_some_labels(self, label_indices: NDArray) -> NDArray:
         """
         This fetches a subset of existing labels.
 
@@ -369,19 +398,23 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         return self.labels[label_indices]
 
-    def get_training_labels(self):
+    def get_training_labels(self) -> NDArray:
         return (
             self.get_all_labels()
-            if self.validation_indices is None
+            if not hasattr(self, "validation_indices")
             else self.get_some_labels(
-                list(set(range(self.labels.shape[0])) - set(self.validation_indices))
+                np.array(
+                    list(
+                        set(range(self.labels.shape[0])) - set(self.validation_indices)
+                    )
+                )
             )
         )
 
-    def get_validation_labels(self):
+    def get_validation_labels(self) -> NDArray:
         return (
-            None
-            if self.validation_indices is None
+            np.zeros(())
+            if not hasattr(self, "validation_indices")
             else self.get_some_labels(self.validation_indices)
         )
 
@@ -389,7 +422,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     Handle the dictionary of supplemental information for each stored entity.
     """
 
-    def set_all_dictionaries(self, dictionaries):
+    def set_all_dictionaries(self, dictionaries: Iterable[MutableMapping]) -> None:
         """
         Set the entire database of dictionaries -- one per feature vector -- from a
         supplied list of Python dict objects.
@@ -401,55 +434,59 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         if isinstance(dictionaries, list) and all(
             [isinstance(e, dict) for e in dictionaries]
         ):
-            self.dictionaries = dictionaries
+            self.dictionaries: List[MutableMapping] = dictionaries
         else:
             raise ValueError(
                 "The argument to set_all_dictionaries must be a list of Python "
                 "dict objects"
             )
 
-    def get_all_dictionaries(self):
+    def get_all_dictionaries(self) -> Iterable[MutableMapping]:
         """
         Get the entire database of dictionaries as a list (or tuple) of Python dict
         objects.
         """
-        return self.dictionaries
+        return self.dictionaries if hasattr(self, "dictionaries") else list()
 
-    def clear_all_dictionaries(self):
+    def clear_all_dictionaries(self) -> None:
         """
         Remove all dictionaries from the database
         """
-        self.dictionaries = None
+        del self.dictionaries
 
-    def set_validation_indices(self, validation_indices):
+    def set_validation_indices(self, validation_indices: NDArray) -> None:
         """
         Mark which feature vectors are reserved for validation, and should not
         participate in training.
         """
-        if isinstance(validation_indices, (list, tuple)) and all(
-            isinstance(e, int) for e in validation_indices
-        ):
-            self.validation_indices = validation_indices
+        if isinstance(validation_indices, np.ndarray):
+            self.validation_indices: NDArray = validation_indices
         else:
             raise ValueError(
                 "The argument to set_validation_indices must be a tuple or list of "
                 "integers"
             )
 
-    def get_validation_indices(self):
+    def get_validation_indices(self) -> NDArray:
         """
         Retrieve the indices of those feature vectors that are reserved for validation,
         and should not participate in training.
         """
-        return self.validation_indices
+        return (
+            self.validation_indices
+            if hasattr(self, "validation_indices")
+            else np.zeros(())
+        )
 
-    def clear_validation_indices(self):
+    def clear_validation_indices(self) -> None:
         """
         Indicate that no feature vectors are reserved for validation.
         """
-        self.validation_indices = None
+        del self.validation_indices
 
-    def set_some_dictionaries(self, dictionary_indices, dictionaries):
+    def set_some_dictionaries(
+        self, dictionary_indices: NDArray, dictionaries: Iterable[MutableMapping]
+    ) -> None:
         """
         This overwrites existing dictionaries.  It does not (yet) handle insert, delete,
         or append.
@@ -470,9 +507,12 @@ class GenericDatasetHandler(AbstractDatasetHandler):
                 "dictionaries are supplied in a list instead of a tuple"
             )
 
-        self.dictionaries[dictionary_indices] = dictionaries
+        for k, v in zip(dictionary_indices, dictionaries):
+            self.dictionaries[k] = v
 
-    def get_some_dictionaries(self, dictionary_indices):
+    def get_some_dictionaries(
+        self, dictionary_indices: NDArray
+    ) -> Iterable[MutableMapping]:
         """
         This fetches a subset of existing dictionaries.
 
@@ -482,14 +522,20 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         returns {'a': 1, 'b': 2} but use of dictionary_indices=[5] returns [{'a': 1,
         'b': 2}].
         """
-        return self.dictionaries[dictionary_indices]
+        return (
+            [self.dictionaries[k] for k in dictionary_indices]
+            if hasattr(self, "dictionaries")
+            else list()
+        )
 
     """
     Handle operations not specific to the feature vectors, labels, or dictionaries of
     supplemental information of each stored entity.
     """
 
-    def set_all_label_definitions(self, label_definitions):
+    def set_all_label_definitions(
+        self, label_definitions: Iterable[MutableMapping]
+    ) -> None:
         """
         Parameters
         ----------
@@ -503,30 +549,32 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         if isinstance(label_definitions, list) and all(
             [isinstance(e, dict) for e in label_definitions]
         ):
-            self.label_definitions = label_definitions
+            self.label_definitions: List[MutableMapping] = label_definitions
         else:
             raise ValueError(
                 "The argument to set_all_label_definitions must be a list of Python "
                 "dict objects"
             )
 
-    def get_all_label_definitions(self):
+    def get_all_label_definitions(self) -> Iterable[MutableMapping]:
         """
         Returns
         -------
         label_definitions: dict
             See set_all_label_definitions for the dict format.
         """
-        return self.label_definitions
+        return self.label_definitions if hasattr(self, "label_definitions") else list()
 
-    def check_data_consistency(self):
+    def check_data_consistency(self) -> bool:
         # Check whether among feature vectors, labels, and dictionaries that were
         # supplied, are they for the same number of entities?
         feature_vectors_length = (
-            0 if self.feature_vectors is None else self.feature_vectors.shape[0]
+            self.feature_vectors.shape[0] if hasattr(self, "feature_vectors") else 0
         )
-        labels_length = 0 if self.labels is None else self.labels.shape[0]
-        dictionaries_length = 0 if self.dictionaries is None else len(self.dictionaries)
+        labels_length = self.labels.shape[0] if hasattr(self, "labels") else 0
+        dictionaries_length = (
+            len(self.dictionaries) if hasattr(self, "dictionaries") else 0
+        )
         # Eliminate duplicates
         all_lengths = set([feature_vectors_length, labels_length, dictionaries_length])
         lengths_test = len(all_lengths) == 1 or (
@@ -536,12 +584,12 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         # Check whether among labels and label_definitions that were supplied, are they
         # for the same number of kinds of labels?
         labels_width = (
-            0
-            if self.labels is None
-            else (1 if len(self.labels.shape) == 1 else self.labels.shape[1])
+            (1 if len(self.labels.shape) == 1 else self.labels.shape[1])
+            if hasattr(self, "labels")
+            else 0
         )
         label_definitions_width = (
-            0 if self.label_definitions is None else len(self.label_definitions)
+            len(self.label_definitions) if hasattr(self, "label_definitions") else 0
         )
         all_widths = set([labels_width, label_definitions_width])
         widths_test = len(all_widths) == 1 or (len(all_widths) == 2 and 0 in all_widths)
@@ -567,7 +615,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             )
         )
 
-        mesgs = list()
+        mesgs: List[str] = list()
         if not lengths_test:
             mesgs += [
                 f"height(feature_vectors) = {feature_vectors_length}, "

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -16,11 +16,14 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 from datetime import datetime
 import enum
-import keras
 import numpy as np
 import scipy.stats
+import tensorflow as tf
+from numpy.typing import NDArray
+from typing import Dict, List, Mapping, MutableMapping, Sequence
 
 
 class ModelStep(enum.Enum):
@@ -40,9 +43,9 @@ class ModelStep(enum.Enum):
     ON_PREDICT_BATCH_END = 345
 
 
-# !!! Does it matter that this model.Logger code requires `import keras` because of its
-# !!! superclass?  In particular, someone who is using only torch might nonetheless be
-# !!! required to install tensorflow.
+# !!! Does it matter that this model.Logger code requires `import tensorflow.keras`
+# !!! because of its required to install tensorflow.  superclass?  In particular,
+# !!! someone who is using only torch might nonetheless be
 
 # !!! Does it matter that this model.Logger code requires `import torch` because of the
 # !!! use of torch.utils.tensorboard.SummaryWriter in
@@ -50,37 +53,40 @@ class ModelStep(enum.Enum):
 # !!! tensorflow might nonetheless be required to install torch.
 
 
-class Logger(keras.callbacks.Callback):
-    def __init__(self, model_handler):
+class Logger(tf.keras.callbacks.Callback):
+    def __init__(self, model_handler: AbstractModelHandler) -> None:
         super(Logger, self).__init__()
         self.reset_log()
-        self.training_size = 0
-        self.model_handler = model_handler
+        self.training_size: int = 0
+        self.model_handler: AbstractModelHandler = model_handler
 
-    def reset_log(self):
-        self.log = list()
+    def reset_log(self) -> None:
+        self.log: List = list()
 
-    def get_log(self):
+    def get_log(self) -> List:
         return self.log
 
     def write_some_log_for_tensorboard(
-        self, model_steps, y_dictionary, x_key, *args, **kwargs
-    ):
+        self,
+        model_steps: Sequence[ModelStep],
+        y_dictionary: Mapping,
+        x_key: str,
+        *args,
+        **kwargs,
+    ) -> bool:
         from torch.utils.tensorboard import SummaryWriter
 
-        if self.log is None:
-            return False
         beginning = datetime.utcfromtimestamp(0)
         with SummaryWriter(*args, **kwargs) as writer:
             for entry in self.log:
-                logs = entry["logs"]
-                if entry["model_step"] not in model_steps or logs is None:
+                logs: Mapping = entry["logs"]
+                if entry["model_step"] not in model_steps or len(logs) == 0:
                     continue
                 utc_seconds = (entry["utcnow"] - beginning).total_seconds()
-                x_value = entry[x_key]
+                x_value: float = entry[x_key]
                 for key in logs.keys() & y_dictionary.keys():
-                    name = y_dictionary[key]
-                    y_value = logs[key]
+                    name: str = y_dictionary[key]
+                    y_value: float = logs[key]
                     """
                     print(
                         "Invoking writer.add_scalar("
@@ -100,39 +106,39 @@ class Logger(keras.callbacks.Callback):
                     )
         return True
 
-    def write_train_log_for_tensorboard(self, *args, **kwargs):
+    def write_train_log_for_tensorboard(self, *args, **kwargs) -> bool:
         model_steps = (ModelStep.ON_TRAIN_END,)
-        y_dictionary = {
+        y_dictionary: Mapping = {
             "loss": "Loss/train",
             "val_loss": "Loss/validation",
             "accuracy": "Accuracy/train",
             "val_accuracy": "Accuracy/validation",
         }
-        x_key = "training_size"
+        x_key: str = "training_size"
         return self.write_some_log_for_tensorboard(
             model_steps, y_dictionary, x_key, *args, **kwargs
         )
 
-    def write_epoch_log_for_tensorboard(self, *args, **kwargs):
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
         model_steps = (ModelStep.ON_TRAIN_EPOCH_END,)
-        y_dictionary = {
+        y_dictionary: Mapping = {
             "loss": "Loss/train",
             "val_loss": "Loss/test",
             "accuracy": "Accuracy/train",
             "val_accuracy": "Accuracy/test",
         }
-        x_key = "epoch"
+        x_key: str = "epoch"
         return self.write_some_log_for_tensorboard(
             model_steps, y_dictionary, x_key, *args, **kwargs
         )
 
-    def write_confidence_log_for_tensorboard(self, *args, **kwargs):
-        if self.log is None:
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
+        if len(self.log) == 0:
             return False
-        x_key = "training_size"
+        x_key: str = "training_size"
         beginning = datetime.utcfromtimestamp(0)
-        percentiles = (5, 10, 25, 50)
-        predictions_list = list()
+        percentiles: Sequence[float] = (5, 10, 25, 50)
+        predictions_list: List[NDArray] = list()
 
         from torch.utils.tensorboard import SummaryWriter
 
@@ -152,6 +158,7 @@ class Logger(keras.callbacks.Callback):
                     if (
                         entry.get("logs") is not None
                         and entry.get("logs").get("outputs") is not None
+                        and len(entry["logs"]["outputs"]) > 0
                     ):
                         predictions_list.append(entry["logs"]["outputs"])
 
@@ -160,17 +167,19 @@ class Logger(keras.callbacks.Callback):
                     if len(predictions_list) == 0:
                         continue
 
-                    predictions = np.concatenate(predictions_list, axis=0)
+                    predictions: NDArray = np.concatenate(predictions_list, axis=0)
                     predictions_list = list()
-                    statistcs = self.model_handler.compute_confidence_statistics(
-                        predictions, percentiles
+                    statistcs: Mapping = (
+                        self.model_handler.compute_confidence_statistics(
+                            predictions, percentiles
+                        )
                     )
                     # Report percentile scores
-                    x_value = entry[x_key]
+                    x_value: float = entry[x_key]
                     utc_seconds = (entry["utcnow"] - beginning).total_seconds()
                     for statistic_kind, statistic_percentiles in statistcs.items():
                         for percentile, y_value in statistic_percentiles.items():
-                            name = f"Confidence/{statistic_kind}/{percentile:02d}%"
+                            name: str = f"Confidence/{statistic_kind}/{percentile:02d}%"
                             """
                             print(
                                 "Invoking writer.add_scalar("
@@ -194,7 +203,7 @@ class Logger(keras.callbacks.Callback):
     # invokes it for us, we cannot simply supply training_size through this
     # interface.  Instead we grab it from self.training_size and require that the
     # user has already set that to something reasonable.
-    def on_train_begin(self, logs=None):
+    def on_train_begin(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -204,7 +213,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_train_end(self, logs=None):
+    def on_train_end(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -214,7 +223,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_epoch_begin(self, epoch, logs=None):
+    def on_epoch_begin(self, epoch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -225,7 +234,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_epoch_end(self, epoch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -236,7 +245,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_train_batch_begin(self, batch, logs=None):
+    def on_train_batch_begin(self, batch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -247,7 +256,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_train_batch_end(self, batch, logs=None):
+    def on_train_batch_end(self, batch: int, logs: Dict = dict()) -> None:
         # For tensorflow, logs.keys() == ["loss", "accuracy"]
         self.log.append(
             {
@@ -259,7 +268,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_test_begin(self, logs=None):
+    def on_test_begin(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -269,7 +278,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_test_end(self, logs=None):
+    def on_test_end(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -279,7 +288,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_test_batch_begin(self, batch, logs=None):
+    def on_test_batch_begin(self, batch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -290,7 +299,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_test_batch_end(self, batch, logs=None):
+    def on_test_batch_end(self, batch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -301,7 +310,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_predict_begin(self, logs=None):
+    def on_predict_begin(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -311,7 +320,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_predict_end(self, logs=None):
+    def on_predict_end(self, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -321,7 +330,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_predict_batch_begin(self, batch, logs=None):
+    def on_predict_batch_begin(self, batch: int, logs: Dict = dict()) -> None:
         self.log.append(
             {
                 "utcnow": datetime.utcnow(),
@@ -332,7 +341,7 @@ class Logger(keras.callbacks.Callback):
             }
         )
 
-    def on_predict_batch_end(self, batch, logs=None):
+    def on_predict_batch_end(self, batch: int, logs: Dict = dict()) -> None:
         # For tensorflow, logs.keys() == ["outputs"]
         self.log.append(
             {
@@ -351,7 +360,52 @@ class AbstractModelHandler:
     learning model.
     """
 
-    def set_model(self, model):
+    def __init__(self) -> None:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::__init__ should not be called."
+        )
+        self.logger: Logger
+
+    def reset_log(self: AbstractModelHandler) -> None:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::reset_log should not be called."
+        )
+
+    def get_log(self: AbstractModelHandler) -> List:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::get_log should not be called."
+        )
+
+    def get_logger(self: AbstractModelHandler) -> Logger:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::get_log should not be called."
+        )
+
+    def write_train_log_for_tensorboard(
+        self: AbstractModelHandler, *args, **kwargs
+    ) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::write_train_log_for_tensorboard "
+            "should not be called."
+        )
+
+    def write_epoch_log_for_tensorboard(
+        self: AbstractModelHandler, *args, **kwargs
+    ) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::write_epoch_log_for_tensorboard "
+            "should not be called."
+        )
+
+    def write_confidence_log_for_tensorboard(
+        self: AbstractModelHandler, *args, **kwargs
+    ) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractModelHandler::write_confidence_log_for_tensorboard"
+            " should not be called."
+        )
+
+    def set_model(self: AbstractModelHandler, model) -> None:
         """
         Set the underlying model handled by this model handler.  This is generally
         called just once.
@@ -360,7 +414,7 @@ class AbstractModelHandler:
             "Abstract method AbstractModelHandler::set_model should not be called."
         )
 
-    def set_training_parameters(self):
+    def set_training_parameters(self: AbstractModelHandler) -> None:
         """
         Set the training parameters needed by the underlying model.  This is generally
         called just once and generally includes batch size, number of epochs, loss
@@ -372,12 +426,12 @@ class AbstractModelHandler:
         )
 
     def train(
-        self,
-        train_features,
-        train_labels,
-        validation_features=None,
-        validation_labels=None,
-    ):
+        self: AbstractModelHandler,
+        train_features: NDArray,
+        train_labels: NDArray,
+        validation_features: NDArray = np.zeros(()),
+        validation_labels: NDArray = np.zeros(()),
+    ) -> None:
         """
         Ask the model to train.  This is generally called each time new labels have been
         provided.  Add training weights!!!
@@ -386,7 +440,7 @@ class AbstractModelHandler:
             "Abstract method AbstractModelHandler::train should not be called."
         )
 
-    def predict(self, features, log_it):
+    def predict(self: AbstractModelHandler, features: NDArray, log_it: bool) -> NDArray:
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -396,7 +450,9 @@ class AbstractModelHandler:
             "Abstract method AbstractModelHandler::predict should not be called."
         )
 
-    def compute_confidence_statistics(self, predictions, percentiles):
+    def compute_confidence_statistics(
+        self: AbstractModelHandler, predictions: NDArray, percentiles: Sequence[float]
+    ) -> Mapping:
         """
         Ask that the model provide statistics about its confidence in the supplied
         predictions.
@@ -416,45 +472,54 @@ class GenericModelHandler(AbstractModelHandler):
     framework is being used.
     """
 
-    def __init__(self):
-        super(GenericModelHandler, self).__init__()
-        self.logger = Logger(self)
+    def __init__(self) -> None:
+        # super(GenericModelHandler, self).__init__()
+        self.logger: Logger = Logger(self)
 
-    def reset_log(self):
+    def reset_log(self) -> None:
         self.logger.reset_log()
 
-    def get_log(self):
-        return self.logger.get_log()
+    def get_log(self) -> List:
+        return self.get_logger().get_log()
 
-    def write_train_log_for_tensorboard(self, *args, **kwargs):
+    def get_logger(self) -> Logger:
+        return self.logger
+
+    def write_train_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.logger.write_train_log_for_tensorboard(*args, **kwargs)
 
-    def write_epoch_log_for_tensorboard(self, *args, **kwargs):
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.logger.write_epoch_log_for_tensorboard(*args, **kwargs)
 
-    def write_confidence_log_for_tensorboard(self, *args, **kwargs):
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.logger.write_confidence_log_for_tensorboard(*args, **kwargs)
 
-    def compute_confidence_statistics(self, predictions, percentiles):
+    def compute_confidence_statistics(
+        self, predictions: NDArray, percentiles: Sequence[float]
+    ) -> Mapping:
         # Compute several scores for each prediction.  High scores correspond to high
         # confidence.
 
-        entropy_score = -scipy.stats.entropy(predictions, axis=-1)
-        margin_argsort = np.argsort(predictions, axis=-1)
-        prediction_indices = np.arange(len(predictions))
-        confidence_score = predictions[prediction_indices, margin_argsort[:, -1]]
-        margin_score = (
+        entropy_score: NDArray = -scipy.stats.entropy(predictions, axis=-1)
+        margin_argsort: NDArray = np.argsort(predictions, axis=-1)
+        prediction_indices: NDArray = np.arange(len(predictions))
+        confidence_score: NDArray = predictions[
+            prediction_indices, margin_argsort[:, -1]
+        ]
+        margin_score: NDArray = (
             confidence_score - predictions[prediction_indices, margin_argsort[:, -2]]
         )
 
         # Report percentile scores
-        response = dict()
+        response: MutableMapping = dict()
+        statistic_kind: str
+        source_score: NDArray
         for statistic_kind, source_score in zip(
             ("maximum", "margin", "entropy"),
             (confidence_score, margin_score, entropy_score),
         ):
             response[statistic_kind] = dict()
-            percentile_scores = np.percentile(source_score, percentiles)
+            percentile_scores: NDArray = np.percentile(source_score, percentiles)
             for percentile, percentile_score in zip(percentiles, percentile_scores):
                 response[statistic_kind][percentile] = percentile_score
         return response
@@ -466,22 +531,17 @@ class TensorFlowModelHandler(GenericModelHandler):
     GenericModelHandler routines via TensorFlow.
     """
 
-    def __init__(self):
-        import tensorflow as tf
-
+    def __init__(self) -> None:
         super(TensorFlowModelHandler, self).__init__()
-        self.model = None
         self.loss_function = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=False
         )
 
-    def set_model(self, model):
+    def set_model(self, model) -> None:
         """
         Set the underlying model handled by this model handler.  This is generally
         called just once.
         """
-        import tensorflow as tf
-
         if not isinstance(model, tf.keras.Model):
             raise ValueError(
                 "The parameter of TensorFlowModelHandler.set_model must be of type "
@@ -489,7 +549,7 @@ class TensorFlowModelHandler(GenericModelHandler):
             )
         self.model = model
 
-    def set_training_parameters(self):
+    def set_training_parameters(self) -> None:
         """
         Set the training parameters needed by the underlying model.  This is generally
         called just once and generally includes batch size, number of epochs, loss
@@ -499,26 +559,26 @@ class TensorFlowModelHandler(GenericModelHandler):
 
     def train(
         self,
-        train_features,
-        train_labels,
-        validation_features=None,
-        validation_labels=None,
-    ):
+        train_features: NDArray,
+        train_labels: NDArray,
+        validation_features: NDArray = np.zeros(()),
+        validation_labels: NDArray = np.zeros(()),
+    ) -> None:
         """
         Ask the model to train.  This is generally called each time new labels have been
         provided.  Add training weights!!!
         """
         assert not np.any(np.isnan(train_features))
         assert not np.any(np.isnan(train_labels))
-        assert (validation_features is None) == (validation_labels is None)
+        assert (len(validation_features) == 0) == (len(validation_labels) == 0)
 
         self.model.compile(
             optimizer="adam", loss=self.loss_function, metrics=["accuracy"]
         )
 
-        validation_args = (
+        validation_args: Dict = (
             dict()
-            if validation_features is None
+            if len(validation_features) == 0
             else {"validation_data": (validation_features, validation_labels)}
         )
         # Get `epochs` from training parameters!!!
@@ -533,7 +593,7 @@ class TensorFlowModelHandler(GenericModelHandler):
         )
         # print(f"{repr(self.logger.get_log()) = }")
 
-    def predict(self, features, log_it):
+    def predict(self, features: NDArray, log_it: bool) -> NDArray:
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -541,7 +601,7 @@ class TensorFlowModelHandler(GenericModelHandler):
         """
 
         if log_it:
-            predictions = self.model.predict(
+            predictions: NDArray = self.model.predict(
                 features, verbose=0, callbacks=[self.logger]
             )
         else:
@@ -556,11 +616,10 @@ class PyTorchModelHandler(GenericModelHandler):
     GenericModelHandler routines via PyTorch.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         import torch
 
         super(PyTorchModelHandler, self).__init__()
-        self.model = None
 
         def categorical_cross_entropy(y_pred, y_true):
             y_pred = torch.clamp(y_pred, 1e-9, 1 - 1e-9)
@@ -569,7 +628,7 @@ class PyTorchModelHandler(GenericModelHandler):
 
         self.criterion = categorical_cross_entropy
 
-    def set_model(self, model):
+    def set_model(self, model) -> None:
         """
         Set the underlying model handled by this model handler.  This is generally
         called just once.
@@ -586,7 +645,7 @@ class PyTorchModelHandler(GenericModelHandler):
         # torch.save(self.model.state_dict(), PATH)
         # self.model.load_state_dict(torch.load(PATH))
 
-    def set_training_parameters(self):
+    def set_training_parameters(self) -> None:
         """
         Set the training parameters needed by the underlying model.  This is generally
         called just once and generally includes batch size, number of epochs, loss
@@ -596,11 +655,11 @@ class PyTorchModelHandler(GenericModelHandler):
 
     def train(
         self,
-        train_features,
-        train_labels,
-        validation_features=None,
-        validation_labels=None,
-    ):
+        train_features: NDArray,
+        train_labels: NDArray,
+        validation_features: NDArray = np.zeros(()),
+        validation_labels: NDArray = np.zeros(()),
+    ) -> None:
         """
         Ask the model to train.  This is generally called each time new labels have been
         provided.  Add training weights!!!
@@ -609,8 +668,8 @@ class PyTorchModelHandler(GenericModelHandler):
 
         assert not np.any(np.isnan(train_features))
         assert not np.any(np.isnan(train_labels))
-        assert (validation_features is None) == (validation_labels is None)
-        do_validation = validation_features is not None
+        assert (len(validation_features) == 0) == (len(validation_labels) == 0)
+        do_validation: bool = len(validation_features) != 0
 
         # This code heavily mimics
         # https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html.  For a
@@ -621,11 +680,11 @@ class PyTorchModelHandler(GenericModelHandler):
         self.logger.on_train_begin()
 
         # Get `epochs` from training parameters!!!
-        number_of_epochs = 10
+        number_of_epochs: int = 10
         optimizer = torch.optim.SGD(self.model.parameters(), lr=0.001, momentum=0.9)
 
         class ZipDataset(torch.utils.data.Dataset):
-            def __init__(self, train_features, train_labels):
+            def __init__(self, train_features, train_labels) -> None:
                 super(ZipDataset, self).__init__()
                 self.train_features = torch.from_numpy(train_features)
                 self.train_labels = torch.from_numpy(train_labels)
@@ -633,10 +692,10 @@ class PyTorchModelHandler(GenericModelHandler):
             def __len__(self):
                 return self.train_labels.shape[0]
 
-            def __getitem__(self, index):
+            def __getitem__(self, index: int):
                 return self.train_features[index, :], self.train_labels[index]
 
-        train_features_labels = ZipDataset(train_features, train_labels)
+        train_features_labels: ZipDataset = ZipDataset(train_features, train_labels)
         # Instead, get `batch_size` from somewhere!!!
         batch_size = 1
         # DataLoader has additional parameters that we may wish to use!!!
@@ -645,7 +704,7 @@ class PyTorchModelHandler(GenericModelHandler):
         )
 
         if do_validation:
-            validation_features_labels = ZipDataset(
+            validation_features_labels: ZipDataset = ZipDataset(
                 validation_features, validation_labels
             )
             # DataLoader has additional parameters that we may wish to use!!!
@@ -655,7 +714,7 @@ class PyTorchModelHandler(GenericModelHandler):
 
         for epoch in range(number_of_epochs):  # loop over the dataset multiple times
             self.logger.on_epoch_begin(epoch)
-            train_loss = 0.0
+            train_loss: float = 0.0
             train_size = 0
             train_correct = 0.0
             for i, data in enumerate(my_train_data_loader):
@@ -671,7 +730,7 @@ class PyTorchModelHandler(GenericModelHandler):
                 optimizer.step()
                 new_size = inputs.size(0)
                 train_size += new_size
-                new_loss = loss.item() * inputs.size(0)
+                new_loss: float = loss.item() * inputs.size(0)
                 train_loss += new_loss
                 new_correct = (torch.argmax(outputs, dim=1) == labels).float().sum()
                 train_correct += new_correct
@@ -679,7 +738,7 @@ class PyTorchModelHandler(GenericModelHandler):
                 accuracy = (new_correct / new_size).detach().cpu().numpy()
                 if not isinstance(accuracy, (int, float, np.float32, np.float64)):
                     accuracy = accuracy[()]
-                logs = {"loss": loss, "accuracy": accuracy}
+                logs: Dict = {"loss": loss, "accuracy": accuracy}
                 self.logger.on_train_batch_end(i, logs)
             loss = train_loss / train_size
             accuracy = (train_correct / train_size).detach().cpu().numpy()
@@ -687,7 +746,7 @@ class PyTorchModelHandler(GenericModelHandler):
                 accuracy = accuracy[()]
             logs = {"loss": loss, "accuracy": accuracy}
             if do_validation:
-                validation_loss = 0.0
+                validation_loss: float = 0.0
                 validation_size = 0
                 validation_correct = 0.0
                 for i, data in enumerate(my_validation_data_loader):
@@ -700,17 +759,17 @@ class PyTorchModelHandler(GenericModelHandler):
                     validation_loss += new_loss
                     new_correct = (torch.argmax(outputs, dim=1) == labels).float().sum()
                     validation_correct += new_correct
-                val_loss = validation_loss / validation_size
+                val_loss: float = validation_loss / validation_size
                 val_accuracy = (
                     (validation_correct / validation_size).detach().cpu().numpy()[()]
                 )
-                more_logs = {"val_loss": val_loss, "val_accuracy": val_accuracy}
+                more_logs: Dict = {"val_loss": val_loss, "val_accuracy": val_accuracy}
                 logs = {**logs, **more_logs}
             self.logger.on_epoch_end(epoch, logs)
 
         self.logger.on_train_end(logs)  # `logs` is from the last epoch
 
-    def predict(self, features, log_it):
+    def predict(self, features: NDArray, log_it: bool) -> NDArray:
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -720,8 +779,8 @@ class PyTorchModelHandler(GenericModelHandler):
 
         if log_it:
             self.logger.on_predict_begin()
-        predictions = self.model(torch.from_numpy(features))
-        predictions = predictions.detach().cpu().numpy()
+        predictions_raw = self.model(torch.from_numpy(features))
+        predictions: NDArray = predictions_raw.detach().cpu().numpy()
         if log_it:
             self.logger.on_predict_end({"outputs": predictions})
         return predictions
@@ -734,19 +793,19 @@ class AbstractEnsembleModelHandler(GenericModelHandler):
     responses.  It's subclasses deliver an actual implementation.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # super(AbstractEnsembleModelHandler, self).__init__()
         # raise NotImplementedError("Not implemented")
         pass
 
-    def set_model(self, model):
+    def set_model(self, model) -> None:
         """
         Set the underlying model handled by this model handler.  This is generally
         called just once.
         """
         raise NotImplementedError("Not implemented")
 
-    def set_training_parameters(self):
+    def set_training_parameters(self) -> None:
         """
         Set the training parameters needed by the underlying model.  This is generally
         called just once and generally includes batch size, number of epochs, loss
@@ -756,10 +815,10 @@ class AbstractEnsembleModelHandler(GenericModelHandler):
 
     def train(
         self,
-        train_features,
-        train_labels,
-        validation_features=None,
-        validation_labels=None,
+        train_features: NDArray,
+        train_labels: NDArray,
+        validation_features: NDArray = np.zeros(()),
+        validation_labels: NDArray = np.zeros(()),
     ):
         """
         Ask the model to train.  This is generally called each time new labels have been
@@ -767,7 +826,7 @@ class AbstractEnsembleModelHandler(GenericModelHandler):
         """
         raise NotImplementedError("Not implemented")
 
-    def predict(self, features, log_it):
+    def predict(self, features: NDArray, log_it: bool):
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.
@@ -784,18 +843,18 @@ class ExampleEnsembleModelHandler(AbstractEnsembleModelHandler):
     determine the specific implementation of this ensemble.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ExampleEnsembleModelHandler, self).__init__()
         # raise NotImplementedError("Not implemented")
 
-    def set_model(self, model):
+    def set_model(self, model) -> None:
         """
         Set the underlying model handled by this model handler.  This is generally
         called just once.
         """
         raise NotImplementedError("Not implemented")
 
-    def set_training_parameters(self):
+    def set_training_parameters(self) -> None:
         """
         Set the training parameters needed by the underlying model.  This is generally
         called just once and generally includes batch size, number of epochs, loss
@@ -805,18 +864,18 @@ class ExampleEnsembleModelHandler(AbstractEnsembleModelHandler):
 
     def train(
         self,
-        train_features,
-        train_labels,
-        validation_features=None,
-        validation_labels=None,
-    ):
+        train_features: NDArray,
+        train_labels: NDArray,
+        validation_features: NDArray = np.zeros(()),
+        validation_labels: NDArray = np.zeros(()),
+    ) -> None:
         """
         Ask the model to train.  This is generally called each time new labels have been
         provided.  Add training weights!!!
         """
         raise NotImplementedError("Not implemented")
 
-    def predict(self, features, log_it):
+    def predict(self, features: NDArray, log_it: bool) -> NDArray:
         """
         Ask the model to make predictions.  This is generally called after training so
         that the strategy can show the user the new predictions and ask for corrections.

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -16,20 +16,23 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import numpy as np
 import scipy.stats
+from numpy.typing import NDArray
+from typing import List, Mapping, Set, Tuple
 from . import dataset, model
 
 
 class AbstractScoringMetric:
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractScoringMetric::__init__ should not be called."
         )
 
 
 class AbstractDiversityMetric:
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDiversityMetric::__init__ should not be called."
         )
@@ -41,96 +44,128 @@ class AbstractStrategyHandler:
     active learning strategy.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::__init__ should not be called."
         )
 
-    def set_dataset_handler(self, dataset_handler):
+    def set_dataset_handler(
+        self, dataset_handler: dataset.AbstractDatasetHandler
+    ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_dataset_handler "
             "should not be called."
         )
 
-    def get_dataset_handler(self):
+    def get_dataset_handler(self) -> dataset.AbstractDatasetHandler:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::get_dataset_handler "
             "should not be called."
         )
 
-    def set_model_handler(self, model_handler):
+    def set_model_handler(self, model_handler: model.AbstractModelHandler) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_model_handler "
             "should not be called."
         )
 
-    def get_model_handler(self):
+    def get_model_handler(self) -> model.AbstractModelHandler:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::get_model_handler "
             "should not be called."
         )
 
-    def set_desired_outputs(self):
+    def set_desired_outputs(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_desired_outputs "
             "should not be called."
         )
 
-    def set_scoring_metric(self, scoring_metric):
+    def set_scoring_metric(self, scoring_metric: AbstractScoringMetric) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_scoring_metric "
             "should not be called."
         )
 
-    def get_scoring_metric(self):
+    def get_scoring_metric(self) -> AbstractScoringMetric:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::get_scoring_metric "
             "should not be called."
         )
 
-    def clear_scoring_metric(self):
+    def clear_scoring_metric(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::clear_scoring_metric "
             "should not be called."
         )
 
-    def set_diversity_metric(self, diversity_metric):
+    def set_diversity_metric(self, diversity_metric: AbstractDiversityMetric) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_diversity_metric "
             "should not be called."
         )
 
-    def get_diversity_metric(self):
+    def get_diversity_metric(self) -> AbstractDiversityMetric:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::get_diversity_metric "
             "should not be called."
         )
 
-    def clear_diversity_metric(self):
+    def clear_diversity_metric(self) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::clear_diversity_metric "
             "should not be called."
         )
 
-    def set_learning_parameters(self, **parameters):
+    def set_learning_parameters(self, **parameters) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::set_learning_parameters "
             "should not be called."
         )
 
-    def get_learning_parameters(self):
+    def get_learning_parameters(self) -> Mapping:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::get_learning_parameters "
             "should not be called."
         )
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::select_next_indices "
             "should not be called."
         )
 
-    def run(self, labeled_indices):
+    def reset_log(self) -> None:
+        raise NotImplementedError(
+            "Abstract method AbstractStrategyHandler::reset_log should not be called."
+        )
+
+    def get_log(self) -> List:
+        raise NotImplementedError(
+            "Abstract method AbstractStrategyHandler::get_log should not be called."
+        )
+
+    def write_train_log_for_tensorboard(self, *args, **kwargs) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractStrategyHandler::write_train_log_for_tensorboard "
+            "should not be called."
+        )
+
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractStrategyHandler::write_epoch_log_for_tensorboard "
+            "should not be called."
+        )
+
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
+        raise NotImplementedError(
+            "Abstract method AbstractStrategyHandler::write_confidence_log_for"
+            "_tensorboard should not be called."
+        )
+
+    def run(self, labeled_indices: NDArray) -> None:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::run should not be called."
         )
@@ -145,13 +180,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     operations that are dependent upon which active learning strategy is being used.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # super(GenericStrategyHandler, self).__init__()
-        self.scoring_metric = None
-        self.diversity_metric = None
-        self.dataset_handler = None
-        self.model_handler = None
-        self.parameters = None
+        pass
 
         # These parameters must be supplied to the set_learning_parameters call.
         self.required_parameters_keys = [
@@ -163,7 +194,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         # set_learning_parameters call.
         self.valid_parameters_keys = self.required_parameters_keys + list()
 
-    def set_dataset_handler(self, dataset_handler):
+    def set_dataset_handler(
+        self, dataset_handler: dataset.AbstractDatasetHandler
+    ) -> None:
         if not isinstance(dataset_handler, dataset.AbstractDatasetHandler):
             raise ValueError(
                 "The argument to set_dataset_handler must be a (subclass of) "
@@ -171,10 +204,10 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             )
         self.dataset_handler = dataset_handler
 
-    def get_dataset_handler(self):
+    def get_dataset_handler(self) -> dataset.AbstractDatasetHandler:
         return self.dataset_handler
 
-    def set_model_handler(self, model_handler):
+    def set_model_handler(self, model_handler: model.AbstractModelHandler) -> None:
         if not isinstance(model_handler, model.AbstractModelHandler):
             raise ValueError(
                 "The argument to set_model_handler must be a (subclass of) "
@@ -182,10 +215,10 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             )
         self.model_handler = model_handler
 
-    def get_model_handler(self):
+    def get_model_handler(self) -> model.AbstractModelHandler:
         return self.model_handler
 
-    def set_desired_outputs(self):
+    def set_desired_outputs(self) -> None:
         """
         Choose what statistics and other outputs should be recorded during the active
         learning strategy, for use in evaluating the combination of strategy, model, and
@@ -196,7 +229,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         # fetches it.
         raise NotImplementedError("Not implemented")
 
-    def set_scoring_metric(self, scoring_metric):
+    def set_scoring_metric(self, scoring_metric: AbstractScoringMetric) -> None:
         """
         Supply a scoring metric that evaluates each unlabeled feature vector
         (individually) for how useful it would be if only its label were known.  A
@@ -211,19 +244,19 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             )
         self.scoring_metric = scoring_metric
 
-    def get_scoring_metric(self):
+    def get_scoring_metric(self) -> AbstractScoringMetric:
         """
         Retrieve a previously supplied scoring metric
         """
         return self.scoring_metric
 
-    def clear_scoring_metric(self):
+    def clear_scoring_metric(self) -> None:
         """
         Remove a previously supplied scoring metric
         """
-        self.scoring_metric = None
+        del self.scoring_metric
 
-    def set_diversity_metric(self, diversity_metric):
+    def set_diversity_metric(self, diversity_metric: AbstractDiversityMetric) -> None:
         """
         Supply a diversity metric that evaluates a set of feature vectors for their
         diversity.  A higher score indicates that the feature vectors are diverse.  The
@@ -237,19 +270,19 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             )
         self.diversity_metric = diversity_metric
 
-    def get_diversity_metric(self):
+    def get_diversity_metric(self) -> AbstractDiversityMetric:
         """
         Retrieve a previously supplied diversity metric
         """
         return self.diversity_metric
 
-    def clear_diversity_metric(self):
+    def clear_diversity_metric(self) -> None:
         """
         Remove a previously supplied diversity metric
         """
-        self.diversity_metric = None
+        del self.diversity_metric
 
-    def set_learning_parameters(self, **parameters):
+    def set_learning_parameters(self, **parameters) -> None:
         """
         If this strategy has parameters other than a scoring metric or diversity metric,
         set them here.
@@ -261,98 +294,96 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 f"Python dict but is of type {type(parameters)}"
             )
 
-        missing_keys = set(self.required_parameters_keys) - set(parameters)
+        missing_keys: Set = set(self.required_parameters_keys) - set(parameters)
         if len(missing_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters missing required key(s): {missing_keys}"
             )
 
-        invalid_keys = set(parameters) - set(self.valid_parameters_keys)
+        invalid_keys: Set = set(parameters) - set(self.valid_parameters_keys)
         if len(invalid_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters given invalid key(s): {invalid_keys}"
             )
         self.parameters = parameters
 
-    def get_learning_parameters(self):
+    def get_learning_parameters(self) -> Mapping:
         return self.parameters
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         raise NotImplementedError(
             "Abstract method GenericStrategyHandler::select_next_indices should not "
             "be called."
         )
 
-    def reset_log(self):
+    def reset_log(self) -> None:
         self.model_handler.reset_log()
 
-    def get_log(self):
+    def get_log(self) -> List:
         return self.model_handler.get_log()
 
-    def write_train_log_for_tensorboard(self, *args, **kwargs):
+    def write_train_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.model_handler.write_train_log_for_tensorboard(*args, **kwargs)
 
-    def write_epoch_log_for_tensorboard(self, *args, **kwargs):
+    def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.model_handler.write_epoch_log_for_tensorboard(*args, **kwargs)
 
-    def write_confidence_log_for_tensorboard(self, *args, **kwargs):
+    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.model_handler.write_confidence_log_for_tensorboard(*args, **kwargs)
 
-    def run(self, labeled_indices):
+    def run(self, labeled_indices: NDArray) -> None:
         """
         Run the strategy, start to finish.
         """
         # Should we compute uncertainty for all predictions or just the predictions for
         # unlabeled examples?
-        all_p = False
+        all_p: bool = False
 
-        labeled_indices = set(labeled_indices)
-        feature_vectors = self.dataset_handler.get_all_feature_vectors()
-        labels = self.dataset_handler.get_all_labels()
+        feature_vectors: NDArray = self.dataset_handler.get_all_feature_vectors()
+        labels: NDArray = self.dataset_handler.get_all_labels()
         if len(labels.shape) == 1:
             labels = labels[:, np.newaxis]
 
-        validation_indices = self.dataset_handler.get_validation_indices()
-        validation_indices = (
-            None if validation_indices is None else set(validation_indices)
-        )
-        validation_feature_vectors = (
+        validation_indices: NDArray = self.dataset_handler.get_validation_indices()
+        validation_feature_vectors: NDArray = (
             self.dataset_handler.get_validation_feature_vectors()
         )
-        validation_labels = self.dataset_handler.get_validation_labels()
-        assert (validation_indices is None) == (validation_feature_vectors is None)
-        assert (validation_indices is None) == (validation_labels is None)
-        if validation_labels is not None and len(validation_labels.shape) == 1:
+        validation_labels: NDArray = self.dataset_handler.get_validation_labels()
+        if len(validation_labels.shape) == 1:
             validation_labels = validation_labels[:, np.newaxis]
-        validation_args = (
+        validation_args: List = (
             list()
-            if validation_feature_vectors is None
+            if len(validation_feature_vectors.shape) == 0
             else [validation_feature_vectors, validation_labels]
         )
 
-        maximum_queries = self.parameters["maximum_queries"]
-        label_of_interest = self.parameters["label_of_interest"]
+        maximum_queries: int = self.parameters["maximum_queries"]
+        label_of_interest: int = self.parameters["label_of_interest"]
 
-        all_indices = set(range(len(feature_vectors)))
+        all_indices: Set = set(range(len(feature_vectors)))
         for query in range(maximum_queries):
             # Evaluate the pool of possibilities
             print(f"Predicting for {feature_vectors.shape[0]} examples")
             self.predictions = self.model_handler.predict(feature_vectors, log_it=all_p)
             if not all_p:
                 # Log the predictions for the unlabeled examples only
-                unlabeled_indices = all_indices - labeled_indices
-                unlabeled_predictions = self.predictions[list(unlabeled_indices)]
-                self.model_handler.logger.on_predict_end(
+                unlabeled_indices: Set = all_indices - labeled_indices
+                unlabeled_predictions: NDArray = self.predictions[
+                    list(unlabeled_indices)
+                ]
+                self.model_handler.get_logger().on_predict_end(
                     {"outputs": unlabeled_predictions}
                 )
             # Find the next indices to be labeled
-            next_indices = set(
-                self.select_next_indices(labeled_indices, validation_indices)
+            next_indices: NDArray = self.select_next_indices(
+                labeled_indices, validation_indices
             )
-            labeled_indices = labeled_indices | next_indices
-            current_indices = tuple(labeled_indices)
-            current_feature_vectors = feature_vectors[current_indices, :]
-            current_labels = labels[current_indices, label_of_interest]
+            labeled_indices_set: Set = set(labeled_indices) | set(next_indices)
+            current_indices: Tuple = tuple(labeled_indices_set)
+            current_feature_vectors: NDArray = feature_vectors[current_indices, :]
+            current_labels: NDArray = labels[current_indices, label_of_interest]
             # Train with the expanded set of labeled examples
             print(f"Training with {current_feature_vectors.shape[0]} examples")
             self.model_handler.train(
@@ -363,17 +394,19 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         self.predictions = self.model_handler.predict(feature_vectors, log_it=all_p)
         if not all_p:
             # Log the predictions for the unlabeled examples only
-            unlabeled_indices = all_indices - labeled_indices
+            unlabeled_indices = all_indices - labeled_indices_set
             unlabeled_predictions = self.predictions[list(unlabeled_indices)]
             self.model_handler.logger.on_predict_end({"outputs": unlabeled_predictions})
-        self.labeled_indices = labeled_indices
+        self.labeled_indices: NDArray = np.array(labeled_indices_set)
 
 
 class RandomStrategyHandler(GenericStrategyHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super(RandomStrategyHandler, self).__init__()
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         """
         Select new examples to be labeled by the expert.
         `number_to_select_per_query` is the number that should be selected with each
@@ -383,15 +416,11 @@ class RandomStrategyHandler(GenericStrategyHandler):
           examples, including both those examples that have been labeled and those that
           could be selected for labeling.
         """
-        number_to_select = self.parameters["number_to_select_per_query"]
-        feature_vectors = self.dataset_handler.get_all_feature_vectors()
+        number_to_select: int = self.parameters["number_to_select_per_query"]
+        feature_vectors: NDArray = self.dataset_handler.get_all_feature_vectors()
 
         # Make sure the pool to select from is large enough
-        excluded_indices = (
-            labeled_indices
-            if validation_indices is None
-            else labeled_indices | validation_indices
-        )
+        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > feature_vectors.shape[0]:
             raise ValueError(
                 f"Cannot not select {number_to_select} unlabeled feature vectors; only "
@@ -402,43 +431,43 @@ class RandomStrategyHandler(GenericStrategyHandler):
         # currently selected.
         import random
 
-        return random.sample(
-            [
-                example_index
-                for example_index in range(feature_vectors.shape[0])
-                if example_index not in excluded_indices
-            ],
-            number_to_select,
+        return np.array(
+            random.sample(
+                [
+                    example_index
+                    for example_index in range(feature_vectors.shape[0])
+                    if example_index not in excluded_indices
+                ],
+                number_to_select,
+            )
         )
 
 
 class LeastConfidenceStrategyHandler(GenericStrategyHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super(LeastConfidenceStrategyHandler, self).__init__()
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest maximum score.
         """
-        number_to_select = self.parameters["number_to_select_per_query"]
-        number_of_feature_vectors = (
+        number_to_select: int = self.parameters["number_to_select_per_query"]
+        number_of_feature_vectors: int = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices = (
-            labeled_indices
-            if validation_indices is None
-            else labeled_indices | validation_indices
-        )
+        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot not select {number_to_select} unlabeled feature vectors; only "
                 f"{number_of_feature_vectors - len(excluded_indices)} remain."
             )
 
-        predictions = self.predictions
+        predictions: NDArray = self.predictions
         # We assume that via "softmax" or similar, the values are already non-negative
         # and sum to 1.0.
         #   predictions = predictions / predictions.sum(axis=-1, keepdims=True)
@@ -449,44 +478,42 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         if len(excluded_indices):
             predict_score[list(excluded_indices)] = 2
         # Find the lowest scoring examples
-        predict_order = np.argsort(predict_score)[0:number_to_select]
+        predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order
 
 
 class LeastMarginStrategyHandler(GenericStrategyHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super(LeastMarginStrategyHandler, self).__init__()
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest gap between highest and second-highest score.
         """
-        number_to_select = self.parameters["number_to_select_per_query"]
-        number_of_feature_vectors = (
+        number_to_select: int = self.parameters["number_to_select_per_query"]
+        number_of_feature_vectors: int = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices = (
-            labeled_indices
-            if validation_indices is None
-            else labeled_indices | validation_indices
-        )
+        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot not select {number_to_select} unlabeled feature vectors; only "
                 f"{number_of_feature_vectors - len(excluded_indices)} remain."
             )
 
-        predictions = self.predictions
+        predictions: NDArray = self.predictions
         # We assume that via "softmax" or similar, the values are already non-negative
         # and sum to 1.0.
         #   predictions = predictions / predictions.sum(axis=-1, keepdims=True)
         # Find the largest and second largest values, and compute their difference
-        predict_indices = np.arange(len(predictions))
-        predict_argsort = np.argsort(predictions, axis=-1)
-        predict_score = (
+        predict_indices: NDArray = np.arange(len(predictions))
+        predict_argsort: NDArray = np.argsort(predictions, axis=-1)
+        predict_score: NDArray = (
             predictions[predict_indices, predict_argsort[:, -1]]
             - predictions[predict_indices, predict_argsort[:, -2]]
         )
@@ -495,37 +522,35 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         if len(excluded_indices):
             predict_score[list(excluded_indices)] = 2
         # Find the lowest scoring examples
-        predict_order = np.argsort(predict_score)[0:number_to_select]
+        predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order
 
 
 class EntropyStrategyHandler(GenericStrategyHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super(EntropyStrategyHandler, self).__init__()
 
-    def select_next_indices(self, labeled_indices, validation_indices=None):
+    def select_next_indices(
+        self, labeled_indices: NDArray, validation_indices: NDArray = np.zeros(())
+    ) -> NDArray:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the highest entropy.
         """
-        number_to_select = self.parameters["number_to_select_per_query"]
-        number_of_feature_vectors = (
+        number_to_select: int = self.parameters["number_to_select_per_query"]
+        number_of_feature_vectors: int = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices = (
-            labeled_indices
-            if validation_indices is None
-            else labeled_indices | validation_indices
-        )
+        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot not select {number_to_select} unlabeled feature vectors; only "
                 f"{number_of_feature_vectors - len(excluded_indices)} remain."
             )
 
-        predictions = self.predictions
+        predictions: NDArray = self.predictions
         # We assume that via "softmax" or similar, the values are already non-negative
         # and sum to 1.0.
         #   predictions = predictions / predictions.sum(axis=-1, keepdims=True)
@@ -538,5 +563,5 @@ class EntropyStrategyHandler(GenericStrategyHandler):
         if len(excluded_indices):
             predict_score[list(excluded_indices)] = 2
         # Find the lowest scoring examples
-        predict_order = np.argsort(predict_score)[0:number_to_select]
+        predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,14 @@ dependencies = [
     "h5py",
     "numpy",
     "scipy",
+    "tensorflow",
+    "torch",
 ]
 dynamic = ["version", "description"]
 
-[project.optional.dependencies]
-torch = ["torch >= 1.11"]
-tensorflow = ["tensorflow >= 2.6"]
+# [project.optional-dependencies]
+# torch = ["torch >= 1.11"]
+# tensorflow = ["tensorflow >= 2.6"]
 
 [project.urls]
 Source = "https://github.com/DigitalSlideArchive/ALBench"

--- a/test/check.py
+++ b/test/check.py
@@ -16,10 +16,12 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import numpy as np
+from typing import Any
 
 
-def check_deeply_numeric(x):
+def check_deeply_numeric(x: Any):
     return (
         isinstance(x, (int, float, np.float32))
         or (

--- a/test/create.py
+++ b/test/create.py
@@ -16,26 +16,30 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
+from typing import Dict, List, Optional, Sequence, Tuple
+from numpy.typing import NDArray
+
 
 def create_dataset(
-    number_of_superpixels, number_of_features, number_of_categories_by_label, **kwargs
-):
+    number_of_superpixels: int,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    **kwargs,
+) -> Tuple[NDArray, List[Dict], NDArray]:
     """
     Create a toy set of feature vectors
     """
     import numpy as np
 
     rng = np.random.default_rng()
-    my_feature_vectors = rng.normal(
+    my_feature_vectors: NDArray = rng.normal(
         0, 1, size=(number_of_superpixels, number_of_features)
     ).astype(np.float32)
 
-    if not isinstance(number_of_categories_by_label, (list, tuple)):
-        number_of_categories_by_label = [number_of_categories_by_label]
-
     # Note that apparently TensorFlow requires that the labels be consecutive integers
     # starting with zero.  So, we will use -1 for "unknown".
-    my_label_definitions = [
+    my_label_definitions: List[Dict] = [
         {
             -1: {"description": f"Label{label_index}Unknown"},
             **{
@@ -52,35 +56,37 @@ def create_dataset(
 
     # Create a random label for each superpixel.  Avoid -1, which we are using for
     # "unknown".
-    my_labels = [
-        np.array(
-            np.clip(
-                np.floor(my_feature_vectors[:, 0:1] ** 2 * count + 1), 0, count - 1
-            ),
-            dtype=int,
-        )
-        for count in number_of_categories_by_label
-    ]
-    if len(my_labels) == 1:
-        my_labels = my_labels[0]
-    else:
-        my_labels = np.append(*my_labels, 1)
+    my_labels: NDArray = np.concatenate(
+        [
+            np.array(
+                np.clip(
+                    np.floor(my_feature_vectors[:, 0:1] ** 2 * count + 1), 0, count - 1
+                ),
+                dtype=int,
+            )
+            for count in number_of_categories_by_label
+        ],
+        axis=1,
+    )
 
     return my_feature_vectors, my_label_definitions, my_labels
 
 
 def create_dataset_4598_1280_4(
-    number_of_superpixels, number_of_features, number_of_categories_by_label, **kwargs
-):
+    number_of_superpixels: int,
+    number_of_features: int,
+    number_of_categories_by_label: int,
+    **kwargs,
+) -> Tuple[NDArray, List[Dict], NDArray]:
     import h5py as h5
     import numpy as np
 
     """Use the dataset from test/TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py"""
-    filename = "TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py"
+    filename: str = "TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py"
     with h5.File(filename) as ds:
-        my_feature_vectors = np.array(ds["features"])
-        my_labels = np.array(ds["labels"])
-    my_label_definitions = [
+        my_feature_vectors: NDArray = np.array(ds["features"])
+        my_labels: NDArray = np.array(ds["labels"])
+    my_label_definitions: List[Dict] = [
         {
             0: {"description": "other"},
             1: {"description": "tumor"},
@@ -98,10 +104,10 @@ def create_dataset_4598_1280_4(
 
 
 def create_toy_tensorflow_model(
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
-    hidden_units=128,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
+    hidden_units: int = 128,
     **kwargs,
 ):
     """
@@ -109,7 +115,7 @@ def create_toy_tensorflow_model(
     """
     import tensorflow as tf
 
-    number_of_categories = number_of_categories_by_label[label_to_test]
+    number_of_categories: int = number_of_categories_by_label[label_to_test]
     model = tf.keras.models.Sequential(
         [
             tf.keras.Input(shape=(number_of_features,)),
@@ -122,13 +128,13 @@ def create_toy_tensorflow_model(
 
 
 def create_tensorflow_model_with_dropout(
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
-    hidden_units=32,
-    dropout=0.3,
-    noise_shape=None,
-    seed=145,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
+    hidden_units: int = 32,
+    dropout: float = 0.3,
+    noise_shape: Optional[Sequence[int]] = None,
+    seed: int = 145,
     **kwargs,
 ):
     """
@@ -136,7 +142,7 @@ def create_tensorflow_model_with_dropout(
     """
     import tensorflow as tf
 
-    number_of_categories = number_of_categories_by_label[label_to_test]
+    number_of_categories: int = number_of_categories_by_label[label_to_test]
     model = tf.keras.models.Sequential(
         [
             tf.keras.Input(shape=(number_of_features,)),
@@ -153,10 +159,10 @@ def create_tensorflow_model_with_dropout(
 
 
 def create_toy_pytorch_model(
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
-    hidden_units=128,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
+    hidden_units: int = 128,
     **kwargs,
 ):
     """
@@ -165,7 +171,7 @@ def create_toy_pytorch_model(
     import torch
 
     class TorchToy(torch.nn.modules.module.Module):
-        def __init__(self, number_of_features, number_of_categories):
+        def __init__(self, number_of_features: int, number_of_categories: int):
             super(TorchToy, self).__init__()
             self.fc1 = torch.nn.Linear(number_of_features, hidden_units)
             self.relu1 = torch.nn.ReLU()
@@ -179,19 +185,19 @@ def create_toy_pytorch_model(
             x = self.softmax1(x)
             return x
 
-    number_of_categories = number_of_categories_by_label[label_to_test]
+    number_of_categories: int = number_of_categories_by_label[label_to_test]
     model = TorchToy(number_of_features, number_of_categories)
     return model
 
 
 def create_pytorch_model_with_dropout(
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
-    hidden_units=32,
-    dropout=0.3,
-    noise_shape=None,
-    seed=145,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
+    hidden_units: int = 32,
+    dropout: float = 0.3,
+    noise_shape: Optional[Sequence[int]] = None,
+    seed: int = 145,
     **kwargs,
 ):
     """
@@ -200,7 +206,7 @@ def create_pytorch_model_with_dropout(
     import torch
 
     class TorchToyWithDropout(torch.nn.modules.module.Module):
-        def __init__(self, number_of_features, number_of_categories):
+        def __init__(self, number_of_features: int, number_of_categories: int):
             super(TorchToyWithDropout, self).__init__()
             self.fc1 = torch.nn.Linear(number_of_features, hidden_units)
             self.relu1 = torch.nn.ReLU()
@@ -216,6 +222,6 @@ def create_pytorch_model_with_dropout(
             x = self.softmax1(x)
             return x
 
-    number_of_categories = number_of_categories_by_label[label_to_test]
+    number_of_categories: int = number_of_categories_by_label[label_to_test]
     model = TorchToyWithDropout(number_of_features, number_of_categories)
     return model

--- a/test/exercise.py
+++ b/test/exercise.py
@@ -16,17 +16,20 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
+import numpy as np
 from create import create_dataset
 from create import create_toy_pytorch_model
 from create import create_toy_tensorflow_model
+from typing import List
 
 
 def exercise_dataset_handler(
     my_dataset_handler,
-    number_of_superpixels,
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
+    number_of_superpixels: int,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
     **kwargs,
 ):
     print(
@@ -52,8 +55,8 @@ def exercise_dataset_handler(
     # !!! Test clear_validation_indices(self):
 
     # raise NotImplementedError("Not implemented")
-    assert my_dataset_handler.get_all_feature_vectors() is None
-    assert my_dataset_handler.get_all_labels() is None
+    assert np.equal(my_dataset_handler.get_all_feature_vectors(), np.zeros(())).all()
+    assert np.equal(my_dataset_handler.get_all_labels(), np.zeros(())).all()
 
     # Create random feature vectors
     my_feature_vectors, my_label_definitions, my_labels = create_dataset(
@@ -63,14 +66,14 @@ def exercise_dataset_handler(
     my_dataset_handler.set_all_feature_vectors(my_feature_vectors)
     assert my_dataset_handler.get_all_feature_vectors() is my_feature_vectors
     my_dataset_handler.clear_all_feature_vectors()
-    assert my_dataset_handler.get_all_feature_vectors() is None
+    assert np.equal(my_dataset_handler.get_all_feature_vectors(), np.zeros(())).all()
 
     my_dataset_handler.set_all_labels(my_labels)
     assert my_dataset_handler.get_all_labels() is my_labels
     my_dataset_handler.set_all_labels(my_labels[label_to_test])
     assert (my_dataset_handler.get_all_labels() == my_labels[label_to_test]).all()
     my_dataset_handler.clear_all_labels()
-    assert my_dataset_handler.get_all_labels() is None
+    assert np.equal(my_dataset_handler.get_all_labels(), np.zeros(())).all()
 
     my_dataset_handler.set_all_feature_vectors(my_feature_vectors)
     my_dataset_handler.set_all_labels(my_labels)
@@ -80,9 +83,9 @@ def exercise_dataset_handler(
 
 def exercise_model_handler(
     my_model_handler,
-    number_of_features,
-    number_of_categories_by_label,
-    label_to_test,
+    number_of_features: int,
+    number_of_categories_by_label: List[int],
+    label_to_test: int,
     **kwargs,
 ):
     import al_bench as alb

--- a/test/test_0000_imports.py
+++ b/test/test_0000_imports.py
@@ -16,13 +16,18 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 
-def test_0000_imports():
+
+def test_0000_imports() -> None:
     """Purpose: Test that needed parts of needed packages are available"""
     from al_bench import dataset  # noqa F401
     from al_bench import model  # noqa F401
     from al_bench import strategy  # noqa F401
+    from al_bench.dataset import AbstractDatasetHandler  # noqa F401
     from al_bench.dataset import GenericDatasetHandler  # noqa F401
+    from al_bench.model import AbstractModelHandler  # noqa F401
+    from al_bench.model import Logger  # noqa F401
     from al_bench.model import ModelStep  # noqa F401
     from al_bench.model import PyTorchModelHandler  # noqa F401
     from al_bench.model import TensorFlowModelHandler  # noqa F401
@@ -31,27 +36,70 @@ def test_0000_imports():
     from al_bench.strategy import LeastMarginStrategyHandler  # noqa F401
     from al_bench.strategy import RandomStrategyHandler  # noqa F401
     from datetime import datetime  # noqa F401
+    from enum import Enum  # noqa F401
     from h5py import File  # noqa F401
-    from numpy import append  # noqa F401
+    from numpy import amax  # noqa F401
+    from numpy import any  # noqa F401
+    from numpy import arange  # noqa F401
+    from numpy import argsort  # noqa F401
     from numpy import array  # noqa F401
     from numpy import clip  # noqa F401
+    from numpy import concatenate  # noqa F401
+    from numpy import equal  # noqa F401
     from numpy import float32  # noqa F401
     from numpy import float64  # noqa F401
     from numpy import floor  # noqa F401
+    from numpy import isnan  # noqa F401
+    from numpy import nan  # noqa F401
     from numpy import ndarray  # noqa F401
+    from numpy import newaxis  # noqa F401
+    from numpy import percentile  # noqa F401
+    from numpy import random  # noqa F401
+    from numpy import typing  # noqa F401
+    from numpy import zeros  # noqa F401
     from numpy.random import default_rng  # noqa F401
+    from numpy.typing import NDArray  # noqa F401
+    from os import path  # noqa F401
     from os.path import join  # noqa F401
     from random import sample  # noqa F401
     from re import search  # noqa F401
+    from scipy import stats  # noqa F401
+    from scipy.stats import entropy  # noqa F401
+    from tensorflow import keras  # noqa F401
     from tensorflow.keras import Input  # noqa F401
+    from tensorflow.keras import Model  # noqa F401
+    from tensorflow.keras import layers  # noqa F401
+    from tensorflow.keras import models  # noqa F401
+    from tensorflow.keras.callbacks import Callback  # noqa F401
     from tensorflow.keras.layers import Dense  # noqa F401
     from tensorflow.keras.layers import Dropout  # noqa F401
+    from tensorflow.keras.losses import SparseCategoricalCrossentropy  # noqa F401
     from tensorflow.keras.models import Sequential  # noqa F401
+    from torch import argmax  # noqa F401
+    from torch import clamp  # noqa F401
+    from torch import eye  # noqa F401
+    from torch import from_numpy  # noqa F401
+    from torch import load  # noqa F401
+    from torch import log  # noqa F401
+    from torch import nn  # noqa F401
+    from torch import save  # noqa F401
     from torch.nn import Dropout  # noqa F401
     from torch.nn import Linear  # noqa F401
     from torch.nn import ReLU  # noqa F401
     from torch.nn import Softmax  # noqa F401
+    from torch.nn.modules import module  # noqa F401
     from torch.nn.modules.module import Module  # noqa F401
+    from torch.optim import SGD  # noqa F401
+    from torch.utils import tensorboard  # noqa F401
+    from torch.utils.data import DataLoader  # noqa F401
+    from torch.utils.data import Dataset  # noqa F401
+    from torch.utils.tensorboard import SummaryWriter  # noqa F401
+    from typing import Dict  # noqa F401
+    from typing import Iterable  # noqa F401
+    from typing import List  # noqa F401
+    from typing import Mapping  # noqa F401
+    from typing import MutableMapping  # noqa F401
+    from typing import Sequence  # noqa F401
 
     pass
 

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -16,15 +16,17 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import al_bench as alb
 from exercise import exercise_dataset_handler
+from typing import Any, Dict, Type
 
 
-def test_0010_dataset_handler_interface():
+def test_0010_dataset_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = {
+    parameters: Dict[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],
@@ -32,8 +34,9 @@ def test_0010_dataset_handler_interface():
     }
 
     # Try trivial exercises on the handler interface
+    DatasetHandler: Type[alb.dataset.AbstractDatasetHandler]
     for DatasetHandler in (alb.dataset.GenericDatasetHandler,):
-        my_dataset_handler = DatasetHandler()
+        my_dataset_handler: alb.dataset.AbstractDatasetHandler = DatasetHandler()
         exercise_dataset_handler(my_dataset_handler, **parameters)
 
 

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -16,15 +16,17 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import al_bench as alb
 from exercise import exercise_model_handler
+from typing import Any, Dict, Type
 
 
-def test_0020_model_handler_interface():
+def test_0020_model_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = {
+    parameters: Dict[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],
@@ -32,11 +34,12 @@ def test_0020_model_handler_interface():
     }
 
     # Try trivial exercises on the handler interface
+    ModelHandler: Type[alb.model.AbstractModelHandler]
     for ModelHandler in (
         alb.model.TensorFlowModelHandler,
         alb.model.PyTorchModelHandler,
     ):
-        my_model_handler = ModelHandler()
+        my_model_handler: alb.model.AbstractModelHandler = ModelHandler()
         exercise_model_handler(my_model_handler, **parameters)
 
 

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -16,15 +16,17 @@
 #
 # ==========================================================================
 
+from __future__ import annotations
 import al_bench as alb
 from exercise import exercise_strategy_handler
+from typing import Any, Dict, Type
 
 
-def test_0030_strategy_handler_interfac():
+def test_0030_strategy_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters = {
+    parameters: Dict[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],
@@ -32,15 +34,16 @@ def test_0030_strategy_handler_interfac():
     }
 
     # Try trivial exercises on the handler interface
+    StrategyHandler: Type[alb.strategy.AbstractStrategyHandler]
     for StrategyHandler in (
         alb.strategy.RandomStrategyHandler,
         alb.strategy.LeastConfidenceStrategyHandler,
         alb.strategy.LeastMarginStrategyHandler,
         alb.strategy.EntropyStrategyHandler,
     ):
-        my_strategy_handler = StrategyHandler()
+        my_strategy_handler: alb.strategy.AbstractStrategyHandler = StrategyHandler()
         exercise_strategy_handler(my_strategy_handler, **parameters)
 
 
 if __name__ == "__main__":
-    test_0030_strategy_handler_interfac()
+    test_0030_strategy_handler_interface()


### PR DESCRIPTION
The correctness of the code with respect to these new type hints can be checked (linted) with
```shell
cd ALBench; mypy test/test_*.py
```
On my system, the remaining errors are almost exclusively about packages / libraries for which `mypy` does not find type hints.  For substantial errors, I see only `mypy` confusion about the `torch` `detach` command.