### PR TITLE
Query oracle to get new labels

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -314,11 +314,10 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             self.get_all_feature_vectors()
             if not hasattr(self, "validation_indices")
             else self.get_some_feature_vectors(
-                np.array(
-                    list(
-                        set(range(self.feature_vectors.shape[0]))
-                        - set(self.validation_indices)
-                    )
+                np.fromiter(
+                    set(range(self.feature_vectors.shape[0]))
+                    - set(self.validation_indices),
+                    dtype=np.int64,
                 )
             )
         )
@@ -405,10 +404,9 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             self.get_all_labels()
             if not hasattr(self, "validation_indices")
             else self.get_some_labels(
-                np.array(
-                    list(
-                        set(range(self.labels.shape[0])) - set(self.validation_indices)
-                    )
+                np.fromiter(
+                    set(range(self.labels.shape[0])) - set(self.validation_indices),
+                    dtype=np.int64,
                 )
             )
         )

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -152,6 +152,16 @@ class AbstractDatasetHandler:
             "should not be called."
         )
 
+    def query_oracle(self, next_indices: NDArray) -> NDArray:
+        """
+        This method queries the oracle for labels for the supplied indices.  It returns
+        all labels.  Note that in a simulation, we already have those labels and there
+        is nothing to do.
+        """
+        raise NotImplementedError(
+            "Abstract method AbstractDatasetHandler::query_oracle should not be called."
+        )
+
     def set_all_dictionaries(self, dictionaries: Iterable[MutableMapping]) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_dictionaries "
@@ -417,6 +427,14 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             if not hasattr(self, "validation_indices")
             else self.get_some_labels(self.validation_indices)
         )
+
+    def query_oracle(self, next_indices: NDArray) -> NDArray:
+        """
+        This method queries the oracle for labels for the supplied indices.  It returns
+        all labels.  Note that in a simulation, we already have those labels and there
+        is nothing to do.
+        """
+        return self.labels
 
     """
     Handle the dictionary of supplemental information for each stored entity.

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -394,6 +394,11 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             next_indices: NDArray = self.select_next_indices(
                 labeled_indices, validation_indices
             )
+            # Query the oracle to get labels for the next_indices.  This call returns
+            # all available labels, old and new.
+            labels = self.dataset_handler.query_oracle(next_indices)
+            if len(labels.shape) == 1:
+                labels = labels[:, np.newaxis]
             # Update the list of labeled_indices
             labeled_indices = np.fromiter(
                 set(labeled_indices) | set(next_indices), dtype=np.int64

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -385,7 +385,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 # Log the predictions for the unlabeled examples only
                 unlabeled_indices: Set = all_indices - set(labeled_indices)
                 unlabeled_predictions: NDArray = self.predictions[
-                    list(unlabeled_indices)
+                    np.fromiter(unlabeled_indices, dtype=np.int64)
                 ]
                 self.model_handler.get_logger().on_predict_end(
                     {"outputs": unlabeled_predictions}
@@ -395,7 +395,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 labeled_indices, validation_indices
             )
             # Update the list of labeled_indices
-            labeled_indices = np.fromiter(set(labeled_indices) | set(next_indices), int)
+            labeled_indices = np.fromiter(
+                set(labeled_indices) | set(next_indices), dtype=np.int64
+            )
             # Do training with the update list of labeled_indices
             current_feature_vectors = feature_vectors[labeled_indices, :]
             current_labels = labels[labeled_indices, label_of_interest]
@@ -409,7 +411,9 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         if not all_p:
             # Log the predictions for the unlabeled examples only
             unlabeled_indices = all_indices - set(labeled_indices)
-            unlabeled_predictions = self.predictions[list(unlabeled_indices)]
+            unlabeled_predictions = self.predictions[
+                np.fromiter(unlabeled_indices, dtype=np.int64)
+            ]
             self.model_handler.logger.on_predict_end({"outputs": unlabeled_predictions})
         self.labeled_indices: NDArray = labeled_indices
 
@@ -494,7 +498,7 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         # Make the currently labeled examples look confident, so that they won't be
         # selected
         if len(excluded_indices):
-            predict_score[list(excluded_indices)] = 2
+            predict_score[np.fromiter(excluded_indices, dtype=np.int64)] = 2
         # Find the lowest scoring examples
         predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order
@@ -540,7 +544,7 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         # Make the currently labeled examples look confident, so that they won't be
         # selected
         if len(excluded_indices):
-            predict_score[list(excluded_indices)] = 2
+            predict_score[np.fromiter(excluded_indices, dtype=np.int64)] = 2
         # Find the lowest scoring examples
         predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order
@@ -583,7 +587,7 @@ class EntropyStrategyHandler(GenericStrategyHandler):
         # Make the currently labeled examples look confident, so that they won't be
         # selected
         if len(excluded_indices):
-            predict_score[list(excluded_indices)] = 2
+            predict_score[np.fromiter(excluded_indices, dtype=np.int64)] = 2
         # Find the lowest scoring examples
         predict_order: NDArray = np.argsort(predict_score)[0:number_to_select]
         return predict_order


### PR DESCRIPTION
In a simulation we have all examples labeled in advance.  However, in actual active learning we have to query an oracle to get labels for additional examples.  The code is now agnostic to simulation vs. non-simulation in that it calls `AbstractDatasetHandler.query_oracle` regardless.  In the case of the simulation, the `GenericDatasetHandler` implementation trivially looks up the already known labels.  Other subclasses of `AbstractDatasetHandler` can override the `query_oracle` method in order to actually query an oracle.

Also, miscellaneous: Use `numpy.fromiter(my_set)` to convert a Python `set` to a Python `numpy.ndarray` (or to a list of indices for subscripting) rather than constructions like `numpy.array(list(my_set))`.