### PR TITLE
BUG: "certainty" vs. "confidence" language

### DIFF
--- a/al_bench/__init__.py
+++ b/al_bench/__init__.py
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-__version__: str = "1.1.0"
+__version__: str = "1.2.0"
 
 """
 

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -24,11 +24,11 @@ from typing import Mapping, MutableMapping, Sequence, Any
 
 
 class ComputeCertainty:
-    all_certainty_types = ["negative_entropy", "confidence", "margin"]
+    all_certainty_types = ["confidence", "margin", "negative_entropy"]
 
     def __init__(self, certainty_type, percentiles, cutoffs):
         """
-        certainty_type can be "negative_entropy", "confidence", or "margin", or a list
+        certainty_type can be "confidence", "margin", or "negative_entropy" or a list
         (or tuple) of one or more of these.  A value of None means all certainty types.
 
         percentiles is a list (or tuple) of percentile values to be computed, e.g., (5,
@@ -98,11 +98,6 @@ class ComputeCertainty:
         predictions = np.sort(predictions, axis=-1)
 
         scores: MutableMapping[str, NDArray] = dict()
-        # When certainty is defined by entropy, compute the entropy of each row and
-        # negate it, because we want larger values (i.e. values that are less negative)
-        # to represent more certainty than smaller values.
-        if "negative_entropy" in self.certainty_type:
-            scores["negative_entropy"] = -scipy.stats.entropy(predictions, axis=-1)
         # When certainty is defined by confidence, use the largest prediction
         # probability.
         if "confidence" in self.certainty_type:
@@ -111,6 +106,11 @@ class ComputeCertainty:
         # and second largest prediction probabilities.
         if "margin" in self.certainty_type:
             scores["margin"] = predictions[..., -1] - predictions[..., -2]
+        # When certainty is defined by entropy, compute the entropy of each row and
+        # negate it, because we want larger values (i.e. values that are less negative)
+        # to represent more certainty than smaller values.
+        if "negative_entropy" in self.certainty_type:
+            scores["negative_entropy"] = -scipy.stats.entropy(predictions, axis=-1)
 
         # Report percentile scores
         percentile: float

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -161,9 +161,9 @@ class AbstractStrategyHandler:
             " should not be called."
         )
 
-    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
+    def write_certainty_log_for_tensorboard(self, *args, **kwargs) -> bool:
         raise NotImplementedError(
-            "Abstract method AbstractStrategyHandler::write_confidence_log_for"
+            "Abstract method AbstractStrategyHandler::write_certainty_log_for"
             "_tensorboard should not be called."
         )
 
@@ -178,7 +178,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     GenericStrategyHandler handles functionality that is agnostic to the choice of the
     active learning strategy.  GenericStrategyHandler is the superclass for
     RandomStrategyHandler, LeastConfidenceStrategyHandler, LeastMarginStrategyHandler,
-    EntropyStrategyHandler, etc.  These subclasses handle AbstractStrategyHandler
+    MaximumEntropyStrategyHandler, etc.  These subclasses handle AbstractStrategyHandler
     operations that are dependent upon which active learning strategy is being used.
     """
 
@@ -334,8 +334,8 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
         return self.model_handler.write_epoch_log_for_tensorboard(*args, **kwargs)
 
-    def write_confidence_log_for_tensorboard(self, *args, **kwargs) -> bool:
-        return self.model_handler.write_confidence_log_for_tensorboard(*args, **kwargs)
+    def write_certainty_log_for_tensorboard(self, *args, **kwargs) -> bool:
+        return self.model_handler.write_certainty_log_for_tensorboard(*args, **kwargs)
 
     def run(self, labeled_indices: NDArray) -> None:
         """
@@ -561,9 +561,9 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         return predict_order
 
 
-class EntropyStrategyHandler(GenericStrategyHandler):
+class MaximumEntropyStrategyHandler(GenericStrategyHandler):
     def __init__(self) -> None:
-        super(EntropyStrategyHandler, self).__init__()
+        super(MaximumEntropyStrategyHandler, self).__init__()
 
     def select_next_indices(
         self,

--- a/example/BayesianExample.ipynb
+++ b/example/BayesianExample.ipynb
@@ -80,6 +80,7 @@
    ],
    "source": [
     "import al_bench as alb\n",
+    "import al_bench.strategy\n",
     "import batchbald_redux as bbald\n",
     "import batchbald_redux.active_learning\n",
     "import batchbald_redux.consistent_mc_dropout\n",
@@ -1773,8 +1774,8 @@
     "    log_dir = os.path.join(all_logs_dir, name)\n",
     "    # Write accuracy and loss information during training\n",
     "    my_strategy_handler.write_train_log_for_tensorboard(log_dir=log_dir)\n",
-    "    # Write confidence statistics during active learning\n",
-    "    my_strategy_handler.write_confidence_log_for_tensorboard(log_dir=log_dir)\n",
+    "    # Write certainty statistics during active learning\n",
+    "    my_strategy_handler.write_certainty_log_for_tensorboard(log_dir=log_dir)\n",
     "print(f\"=== Done at {datetime.now()} ===\")"
    ]
   },
@@ -1789,7 +1790,7 @@
     "\n",
     "<p>Because these are randomized simulations you will not see the same output each time you run them.  Clicking on the \"Scalars\" tab allows one to change the smoothing of the displayed graphics, e.g., to 0.</p>\n",
     "\n",
-    "<p>The Confidence graphs show how the certainty, among samples that are (simulated as) not yet labeled, changes during the active learning process; specifically, as a function of the number of samples that have been labeled so far.  For example, Confidence/margin/10% measures certainty for a sample's prediction as the difference between the two highest-scoring lablels, and the 10% indicates that this is the 10 percentile among all unlabeled samples -- which is among the worst performing of these samples.  Confidence/entropy/50% shows the median value among unlabeled samples of the negative entropy.  Confidence/maximum/5% shows the 5 percentile value -- among the very worst -- for a sample's maximum label score, which is the score for its predicted label.</p>"
+    "<p>The Certainty graphs show how the certainty, among samples that are (simulated as) not yet labeled, changes during the active learning process; specifically, as a function of the number of samples that have been labeled so far.  For example, Certainty/margin/10% measures certainty for a sample's prediction as the difference between the two highest-scoring lablels, and the 10% indicates that this is the 10 percentile among all unlabeled samples -- which is among the worst performing of these samples.  Certainty/negative_entropy/50% shows the median value among unlabeled samples of the negative entropy.  Certainty/confidence/5% shows the 5 percentile value -- among the very worst -- for a sample's maximum label score, which is the score for its predicted label.</p>"
    ]
   },
   {

--- a/example/SimpleExample.ipynb
+++ b/example/SimpleExample.ipynb
@@ -82,6 +82,7 @@
    ],
    "source": [
     "import al_bench as alb\n",
+    "import al_bench.strategy\n",
     "import h5py as h5\n",
     "import numpy as np\n",
     "import random\n",
@@ -282,7 +283,7 @@
     "    <li>\"Random\": Select the next samples randomly</li>\n",
     "    <li>\"LeastConfidence\": A sample's certainy is defined as the predicted label's score.</li>\n",
     "    <li>\"LeastMargin\": A sample's certainty is defined by the difference between the predicted label's score and the score of the second-best label.</li>\n",
-    "    <li>\"Entropy\": A sample's scores are interpreted as a probability distribution and its entropy is computed.  Because high entropy means more uncertainty, a sample's certainty is defined to be the negative of the entropy.</li>\n",
+    "    <li>\"MaximumEntropy\": A sample's scores are interpreted as a probability distribution and its entropy is computed.  Because high entropy means more uncertainty, a sample's certainty is defined to be the negative of the entropy.</li>\n",
     "</ol></p>"
    ]
   },
@@ -353,7 +354,7 @@
       "Predicting for 4598 examples\n",
       "Training with 100 examples\n",
       "Predicting for 4598 examples\n",
-      "=== Begin Strategy 'Entropy' at 2023-02-13 10:34:54.286592 ===\n",
+      "=== Begin Strategy 'MaximumEntropy' at 2023-02-13 10:34:54.286592 ===\n",
       "Training with 20 examples\n",
       "Predicting for 4598 examples\n",
       "Training with 30 examples\n",
@@ -390,7 +391,7 @@
     "    (\"Random\", alb.strategy.RandomStrategyHandler()),\n",
     "    (\"LeastConfidence\", alb.strategy.LeastConfidenceStrategyHandler()),\n",
     "    (\"LeastMargin\", alb.strategy.LeastMarginStrategyHandler()),\n",
-    "    (\"Entropy\", alb.strategy.EntropyStrategyHandler()),\n",
+    "    (\"MaximumEntropy\", alb.strategy.MaximumEntropyStrategyHandler()),\n",
     "):\n",
     "    print(f\"=== Begin Strategy {repr(name)} at {datetime.now()} ===\")\n",
     "    my_strategy_handler.set_dataset_handler(my_dataset_handler)\n",
@@ -410,8 +411,8 @@
     "    log_dir = os.path.join(all_logs_dir, name)\n",
     "    # Write accuracy and loss information during training\n",
     "    my_strategy_handler.write_train_log_for_tensorboard(log_dir=log_dir)\n",
-    "    # Write confidence statistics during active learning\n",
-    "    my_strategy_handler.write_confidence_log_for_tensorboard(log_dir=log_dir)\n",
+    "    # Write certainty statistics during active learning\n",
+    "    my_strategy_handler.write_certainty_log_for_tensorboard(log_dir=log_dir)\n",
     "print(f\"=== Done at {datetime.now()} ===\")"
    ]
   },
@@ -426,7 +427,7 @@
     "\n",
     "<p>Because these are randomized simulations you will not see the same output each time you run them.  Clicking on the \"Scalars\" tab allows one to change the smoothing of the displayed graphics, e.g., to 0.</p>\n",
     "\n",
-    "<p>The Confidence graphs show how the certainty, among samples that are (simulated as) not yet labeled, changes during the active learning process; specifically, as a function of the number of samples that have been labeled so far.  For example, Confidence/margin/10% measures certainty for a sample's prediction as the difference between the two highest-scoring lablels, and the 10% indicates that this is the 10 percentile among all unlabeled samples -- which is among the worst performing of these samples.  Confidence/entropy/50% shows the median value among unlabeled samples of the negative entropy.  Confidence/maximum/5% shows the 5 percentile value -- among the very worst -- for a sample's maximum label score, which is the score for its predicted label.</p>"
+    "<p>The Certainty graphs show how the certainty, among samples that are (simulated as) not yet labeled, changes during the active learning process; specifically, as a function of the number of samples that have been labeled so far.  For example, Certainty/margin/10% measures certainty for a sample's prediction as the difference between the two highest-scoring lablels, and the 10% indicates that this is the 10 percentile among all unlabeled samples -- which is among the worst performing of these samples.  Certainty/negative_entropy/50% shows the median value among unlabeled samples of the negative entropy.  Certainty/confidence/5% shows the 5 percentile value -- among the very worst -- for a sample's maximum label score, which is the score for its predicted label.</p>"
    ]
   },
   {

--- a/test/test_0000_imports.py
+++ b/test/test_0000_imports.py
@@ -34,7 +34,7 @@ def test_0000_imports() -> None:
     from al_bench.model import TensorFlowModelHandler  # noqa F401
     from al_bench.model import VariationalBayesianPyTorchModelHandler  # noqa F401
     from al_bench.model import VariationalBayesianTensorFlowModelHandler  # noqa F401
-    from al_bench.strategy import EntropyStrategyHandler  # noqa F401
+    from al_bench.strategy import MaximumEntropyStrategyHandler  # noqa F401
     from al_bench.strategy import LeastConfidenceStrategyHandler  # noqa F401
     from al_bench.strategy import LeastMarginStrategyHandler  # noqa F401
     from al_bench.strategy import RandomStrategyHandler  # noqa F401

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 import al_bench as alb
+import al_bench.dataset
 from exercise import exercise_dataset_handler
 from typing import Any, Dict, Type
 

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 import al_bench as alb
+import al_bench.model
 from exercise import exercise_model_handler
 from typing import Any, Dict, Type
 

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 import al_bench as alb
+import al_bench.strategy
 from exercise import exercise_strategy_handler
 from typing import Any, Dict, Type
 
@@ -39,7 +40,7 @@ def test_0030_strategy_handler_interface() -> None:
         alb.strategy.RandomStrategyHandler,
         alb.strategy.LeastConfidenceStrategyHandler,
         alb.strategy.LeastMarginStrategyHandler,
-        alb.strategy.EntropyStrategyHandler,
+        alb.strategy.MaximumEntropyStrategyHandler,
     ):
         my_strategy_handler: alb.strategy.AbstractStrategyHandler = StrategyHandler()
         exercise_strategy_handler(my_strategy_handler, **parameters)

--- a/test/test_0040_factory.py
+++ b/test/test_0040_factory.py
@@ -18,7 +18,8 @@
 
 from __future__ import annotations
 import numpy as np
-import al_bench.factory as alb_factory
+import al_bench as alb
+import al_bench.factory
 from numpy.typing import NDArray
 from typing import Sequence
 
@@ -54,7 +55,7 @@ def test_0040_factory():
         }
 
     # Get a class from our factory
-    certainty_computer = alb_factory.ComputeCertainty(
+    certainty_computer = alb.factory.ComputeCertainty(
         certainty_type, percentiles, cutoffs
     )
     print(f"all_certainty_types = {certainty_computer.all_certainty_types}")

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 import al_bench as alb
+import al_bench.strategy
 import datetime
 import numpy as np
 import os
@@ -86,7 +87,7 @@ def test_0100_handler_combinations() -> None:
                 alb.strategy.RandomStrategyHandler,
                 alb.strategy.LeastConfidenceStrategyHandler,
                 alb.strategy.LeastMarginStrategyHandler,
-                alb.strategy.EntropyStrategyHandler,
+                alb.strategy.MaximumEntropyStrategyHandler,
             ):
                 # Create fresh handlers and components
                 my_feature_vectors: NDArray
@@ -170,7 +171,7 @@ def test_0100_handler_combinations() -> None:
                 my_strategy_handler.write_train_log_for_tensorboard(
                     log_dir=os.path.join("runs", combination_name)
                 )
-                my_strategy_handler.write_confidence_log_for_tensorboard(
+                my_strategy_handler.write_certainty_log_for_tensorboard(
                     log_dir=os.path.join("runs", combination_name)
                 )
 


### PR DESCRIPTION
This pull request corrects some ambiguity in language.  We now consistently use
* **certainty**: the generic term for which `confidence`, `margin`, and `negative_entropy` are examples.  Sometimes this was instead called `confidence`.
* **confidence**: defines certainty as the probability of the label with maximum probability.  Sometimes this was instead called `certainty` or `maximum`.  In particular, the `compute_confidence_statistics` method is now called `compute_certainty_statistics` and the `write_confidence_log_for_tensorboard` method is now named `write_certainty_log_for_tensorboard`.
* **margin**: defines certainty as the difference between the two highest label probabilities.  This term wasn't misused but is included here for completeness' sake.
* **negative_entropy**: defines certainty as the negative of the entropy of the label probability distribution.  Sometimes this was called `entropy`.  The sign change is now emphasized to reflect that high values correspond to more certainty than low values do, as is already the case for `confidence` and `margin`.  (NB: because the `negative_entropy` values are negative, a higher value is a negative value that is closer to zero.)
* **MaximumEntropyStrategyHandler**: this is the strategy handler that requests labeling of samples with maximum entropy.  This was called `EntropyStrategyHandler` but is changed to better mimic the names `LeastConfidenceStrategyHandler` and `LeastMarginStrategyHandler`.

This pull request bumps the `al_bench` version to `1.2.0`.