### PR TITLE
COMP: Build for Python 3.11

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
         include:
           - batchbald_redux-git-tag: ""


### PR DESCRIPTION
Add build support for Python 3.11.  Not also adding 3.12 because there is no TensorFlow support yet.