### PR TITLE
Additional typing hints

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -593,38 +593,42 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     def check_data_consistency(self) -> bool:
         # Check whether among feature vectors, labels, and dictionaries that were
         # supplied, are they for the same number of entities?
-        feature_vectors_length: int = (
+        feature_vectors_length: int
+        feature_vectors_length = (
             self.feature_vectors.shape[0] if hasattr(self, "feature_vectors") else 0
         )
         labels_length: int = self.labels.shape[0] if hasattr(self, "labels") else 0
-        dictionaries_length: int = (
+        dictionaries_length: int
+        dictionaries_length = (
             len(self.dictionaries) if hasattr(self, "dictionaries") else 0
         )
         # Eliminate duplicates
-        all_lengths: Set[int] = set(
-            [feature_vectors_length, labels_length, dictionaries_length]
-        )
-        lengths_test: bool = len(all_lengths) == 1 or (
+        all_lengths: Set[int]
+        all_lengths = set([feature_vectors_length, labels_length, dictionaries_length])
+        lengths_test: bool
+        lengths_test = len(all_lengths) == 1 or (
             len(all_lengths) == 2 and 0 in all_lengths
         )
 
         # Check whether among labels and label_definitions that were supplied, are they
         # for the same number of kinds of labels?
-        labels_width: int = (
+        labels_width: int
+        labels_width = (
             (1 if len(self.labels.shape) == 1 else self.labels.shape[1])
             if hasattr(self, "labels")
             else 0
         )
-        label_definitions_width: int = (
+        label_definitions_width: int
+        label_definitions_width = (
             len(self.label_definitions) if hasattr(self, "label_definitions") else 0
         )
         all_widths: Set[int] = set([labels_width, label_definitions_width])
-        widths_test: bool = len(all_widths) == 1 or (
-            len(all_widths) == 2 and 0 in all_widths
-        )
+        widths_test: bool
+        widths_test = len(all_widths) == 1 or (len(all_widths) == 2 and 0 in all_widths)
 
         # Check whether every supplied label category has a definition.
-        definitions_test: bool = (
+        definitions_test: bool
+        definitions_test = (
             not widths_test
             or labels_width == 0
             or label_definitions_width == 0

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import h5py as h5
 import numpy as np
 from numpy.typing import NDArray
-from typing import Iterable, List, MutableMapping
+from typing import Iterable, List, Mapping
 
 
 class AbstractDatasetHandler:
@@ -168,13 +168,13 @@ class AbstractDatasetHandler:
             "Abstract method AbstractDatasetHandler::query_oracle should not be called."
         )
 
-    def set_all_dictionaries(self, dictionaries: Iterable[MutableMapping]) -> None:
+    def set_all_dictionaries(self, dictionaries: Iterable[Mapping]) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_dictionaries"
             " should not be called."
         )
 
-    def get_all_dictionaries(self) -> Iterable[MutableMapping]:
+    def get_all_dictionaries(self) -> Iterable[Mapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_dictionaries"
             " should not be called."
@@ -187,9 +187,7 @@ class AbstractDatasetHandler:
         )
 
     def set_some_dictionaries(
-        self,
-        dictionary_indices: NDArray[np.int_],
-        dictionaries: Iterable[MutableMapping],
+        self, dictionary_indices: NDArray[np.int_], dictionaries: Iterable[Mapping]
     ) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_some_dictionaries"
@@ -198,7 +196,7 @@ class AbstractDatasetHandler:
 
     def get_some_dictionaries(
         self, dictionary_indices: NDArray[np.int_]
-    ) -> Iterable[MutableMapping]:
+    ) -> Iterable[Mapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_some_dictionaries"
             " should not be called."
@@ -222,15 +220,13 @@ class AbstractDatasetHandler:
             " should not be called."
         )
 
-    def set_all_label_definitions(
-        self, label_definitions: Iterable[MutableMapping]
-    ) -> None:
+    def set_all_label_definitions(self, label_definitions: Iterable[Mapping]) -> None:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::set_all_label_definitions"
             " should not be called."
         )
 
-    def get_all_label_definitions(self) -> Iterable[MutableMapping]:
+    def get_all_label_definitions(self) -> Iterable[Mapping]:
         raise NotImplementedError(
             "Abstract method AbstractDatasetHandler::get_all_label_definitions"
             " should not be called."
@@ -454,7 +450,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     Handle the dictionary of supplemental information for each stored entity.
     """
 
-    def set_all_dictionaries(self, dictionaries: Iterable[MutableMapping]) -> None:
+    def set_all_dictionaries(self, dictionaries: Iterable[Mapping]) -> None:
         """
         Set the entire database of dictionaries -- one per feature vector -- from a
         supplied list of Python dict objects.
@@ -466,14 +462,14 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         if isinstance(dictionaries, list) and all(
             [isinstance(e, dict) for e in dictionaries]
         ):
-            self.dictionaries: List[MutableMapping] = dictionaries
+            self.dictionaries: List[Mapping] = dictionaries
         else:
             raise ValueError(
                 "The argument to set_all_dictionaries must be a list of Python"
                 " dict objects"
             )
 
-    def get_all_dictionaries(self) -> Iterable[MutableMapping]:
+    def get_all_dictionaries(self) -> Iterable[Mapping]:
         """
         Get the entire database of dictionaries as a list (or tuple) of Python dict
         objects.
@@ -516,9 +512,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         del self.validation_indices
 
     def set_some_dictionaries(
-        self,
-        dictionary_indices: NDArray[np.int_],
-        dictionaries: Iterable[MutableMapping],
+        self, dictionary_indices: NDArray[np.int_], dictionaries: Iterable[Mapping]
     ) -> None:
         """
         This overwrites existing dictionaries.  It does not (yet) handle insert, delete,
@@ -545,7 +539,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
 
     def get_some_dictionaries(
         self, dictionary_indices: NDArray[np.int_]
-    ) -> Iterable[MutableMapping]:
+    ) -> Iterable[Mapping]:
         """
         This fetches a subset of existing dictionaries.
 
@@ -566,9 +560,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     supplemental information of each stored entity.
     """
 
-    def set_all_label_definitions(
-        self, label_definitions: Iterable[MutableMapping]
-    ) -> None:
+    def set_all_label_definitions(self, label_definitions: Iterable[Mapping]) -> None:
         """
         Parameters
         ----------
@@ -582,14 +574,14 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         if isinstance(label_definitions, list) and all(
             [isinstance(e, dict) for e in label_definitions]
         ):
-            self.label_definitions: List[MutableMapping] = label_definitions
+            self.label_definitions: List[Mapping] = label_definitions
         else:
             raise ValueError(
                 "The argument to set_all_label_definitions must be a list of Python"
                 " dict objects"
             )
 
-    def get_all_label_definitions(self) -> Iterable[MutableMapping]:
+    def get_all_label_definitions(self) -> Iterable[Mapping]:
         """
         Returns
         -------

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import h5py as h5
 import numpy as np
 from numpy.typing import NDArray
-from typing import Iterable, List, Mapping
+from typing import Iterable, List, Mapping, Set
 
 
 class AbstractDatasetHandler:
@@ -564,7 +564,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
         Parameters
         ----------
-        label_definitions: dict
+        label_definitions: Mapping
             The argument is, for example, label_definitions = {
                 np.nan: {"description": "unlabeled", "color": "#FFFF00"},
                 1:      {"description": "necrotic",  "color": "#FF0000"},
@@ -593,34 +593,38 @@ class GenericDatasetHandler(AbstractDatasetHandler):
     def check_data_consistency(self) -> bool:
         # Check whether among feature vectors, labels, and dictionaries that were
         # supplied, are they for the same number of entities?
-        feature_vectors_length = (
+        feature_vectors_length: int = (
             self.feature_vectors.shape[0] if hasattr(self, "feature_vectors") else 0
         )
-        labels_length = self.labels.shape[0] if hasattr(self, "labels") else 0
-        dictionaries_length = (
+        labels_length: int = self.labels.shape[0] if hasattr(self, "labels") else 0
+        dictionaries_length: int = (
             len(self.dictionaries) if hasattr(self, "dictionaries") else 0
         )
         # Eliminate duplicates
-        all_lengths = set([feature_vectors_length, labels_length, dictionaries_length])
-        lengths_test = len(all_lengths) == 1 or (
+        all_lengths: Set[int] = set(
+            [feature_vectors_length, labels_length, dictionaries_length]
+        )
+        lengths_test: bool = len(all_lengths) == 1 or (
             len(all_lengths) == 2 and 0 in all_lengths
         )
 
         # Check whether among labels and label_definitions that were supplied, are they
         # for the same number of kinds of labels?
-        labels_width = (
+        labels_width: int = (
             (1 if len(self.labels.shape) == 1 else self.labels.shape[1])
             if hasattr(self, "labels")
             else 0
         )
-        label_definitions_width = (
+        label_definitions_width: int = (
             len(self.label_definitions) if hasattr(self, "label_definitions") else 0
         )
-        all_widths = set([labels_width, label_definitions_width])
-        widths_test = len(all_widths) == 1 or (len(all_widths) == 2 and 0 in all_widths)
+        all_widths: Set[int] = set([labels_width, label_definitions_width])
+        widths_test: bool = len(all_widths) == 1 or (
+            len(all_widths) == 2 and 0 in all_widths
+        )
 
         # Check whether every supplied label category has a definition.
-        definitions_test = (
+        definitions_test: bool = (
             not widths_test
             or labels_width == 0
             or label_definitions_width == 0

--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -460,7 +460,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         function.
         """
         if isinstance(dictionaries, list) and all(
-            [isinstance(e, dict) for e in dictionaries]
+            isinstance(e, dict) for e in dictionaries
         ):
             self.dictionaries: List[Mapping] = dictionaries
         else:
@@ -572,7 +572,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         """
 
         if isinstance(label_definitions, list) and all(
-            [isinstance(e, dict) for e in label_definitions]
+            isinstance(e, dict) for e in label_definitions
         ):
             self.label_definitions: List[Mapping] = label_definitions
         else:
@@ -604,7 +604,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         )
         # Eliminate duplicates
         all_lengths: Set[int]
-        all_lengths = set([feature_vectors_length, labels_length, dictionaries_length])
+        all_lengths = {feature_vectors_length, labels_length, dictionaries_length}
         lengths_test: bool
         lengths_test = len(all_lengths) == 1 or (
             len(all_lengths) == 2 and 0 in all_lengths
@@ -622,7 +622,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         label_definitions_width = (
             len(self.label_definitions) if hasattr(self, "label_definitions") else 0
         )
-        all_widths: Set[int] = set([labels_width, label_definitions_width])
+        all_widths: Set[int] = {labels_width, label_definitions_width}
         widths_test: bool
         widths_test = len(all_widths) == 1 or (len(all_widths) == 2 and 0 in all_widths)
 
@@ -639,11 +639,9 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             or (
                 len(self.labels.shape) == 2
                 and all(
-                    [
-                        len(set(self.labels[:, col]) - set(self.label_definitions[col]))
-                        == 0
-                        for col in range(self.labels.shape[1])
-                    ]
+                    len(set(self.labels[:, col]) - set(self.label_definitions[col]))
+                    == 0
+                    for col in range(self.labels.shape[1])
                 )
             )
         )

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import numpy as np
 import scipy.stats
 from numpy.typing import NDArray
-from typing import Any, List, Mapping, MutableMapping, Sequence
+from typing import Any, Dict, List, Mapping, Sequence
 
 
 class ComputeCertainty:
@@ -116,7 +116,7 @@ class ComputeCertainty:
         # Find the two largest values within each row.
         partitioned = np.partition(predictions, -2, axis=-1)[..., -2:]
 
-        scores: MutableMapping[str, NDArray[np.float_]] = dict()
+        scores: Dict[str, NDArray[np.float_]] = dict()
         # When certainty is defined by confidence, use the largest prediction
         # probability.
         if "confidence" in self.certainty_type:

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -171,7 +171,8 @@ class ComputeCertainty:
             scores["batchbald"][bald_indices, :] = bald_scores[:, np.newaxis]
 
         # Report scores, percentile scores, and cutoff percentiles
-        response: Mapping[str, Mapping[str, Any]] = {
+        response: Mapping[str, Mapping[str, Any]]
+        response = {
             source_name: {
                 "scores": scores[source_name],
                 "percentiles": {

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -55,7 +55,7 @@ class ComputeCertainty:
             certainty_type = self.all_certainty_types
         if isinstance(certainty_type, str):
             certainty_type = [certainty_type]
-        if not all([ct in self.all_certainty_types for ct in certainty_type]):
+        if not all(ct in self.all_certainty_types for ct in certainty_type):
             raise ValueError(f"Something wrong with {certainty_type = }")
         self.certainty_type: Sequence[str] = certainty_type
 
@@ -71,7 +71,7 @@ class ComputeCertainty:
             cutoffs = {certainty_type[0]: cutoffs}
         # If we have no information for a certainty type, default to no cutoffs.
         cutoffs = {**{k: [] for k in certainty_type}, **cutoffs}
-        if not all([cut in certainty_type for cut in cutoffs.keys()]):
+        if not all(cut in certainty_type for cut in cutoffs.keys()):
             raise ValueError(f"Something wrong with {cutoffs = }")
         cutoffs = {key: [float(c) for c in value] for key, value in cutoffs.items()}
         self.cutoffs: Mapping[str, Sequence[float]] = cutoffs
@@ -175,13 +175,12 @@ class ComputeCertainty:
         response = {
             source_name: {
                 "scores": scores[source_name],
-                "percentiles": {
-                    percentile: percentile_score
-                    for percentile, percentile_score in zip(
+                "percentiles": dict(
+                    zip(
                         self.percentiles,
                         np.percentile(scores[source_name], self.percentiles),
                     )
-                },
+                ),
                 "cdf": {
                     cutoff: (scores[source_name] < cutoff).sum() / num_predictions * 100
                     for cutoff in self.cutoffs[source_name]

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -139,7 +139,8 @@ class _AbstractCommon:
 
         def write_train_log_for_tensorboard(self, *args, **kwargs) -> bool:
             model_steps: Tuple[ModelStep] = (ModelStep.ON_TRAIN_END,)
-            y_dictionary: Mapping[str, str] = {
+            y_dictionary: Mapping[str, str]
+            y_dictionary = {
                 "loss": "Loss/train",
                 "val_loss": "Loss/validation",
                 "accuracy": "Accuracy/train",
@@ -152,7 +153,8 @@ class _AbstractCommon:
 
         def write_epoch_log_for_tensorboard(self, *args, **kwargs) -> bool:
             model_steps: Tuple[ModelStep] = (ModelStep.ON_TRAIN_EPOCH_END,)
-            y_dictionary: Mapping[str, str] = {
+            y_dictionary: Mapping[str, str]
+            y_dictionary = {
                 "loss": "Loss/train",
                 "val_loss": "Loss/test",
                 "accuracy": "Accuracy/train",
@@ -200,9 +202,8 @@ class _AbstractCommon:
                         if len(predictions_list) == 0:
                             continue
 
-                        predictions: NDArray[np.float_] = np.concatenate(
-                            predictions_list, axis=0
-                        )
+                        predictions: NDArray[np.float_]
+                        predictions = np.concatenate(predictions_list, axis=0)
                         predictions_list = list()
                         statistcs: Mapping[
                             str, Mapping[float, float]
@@ -211,9 +212,8 @@ class _AbstractCommon:
                         )
                         # Report percentile scores
                         x_value: float = entry[x_key]
-                        utc_seconds: float = (
-                            entry["utcnow"] - beginning
-                        ).total_seconds()
+                        utc_seconds: float
+                        utc_seconds = (entry["utcnow"] - beginning).total_seconds()
                         for statistic_kind, statistic_percentiles in statistcs.items():
                             for percentile, y_value in statistic_percentiles.items():
                                 name: str
@@ -597,15 +597,15 @@ class _Common(_AbstractCommon):
         # predictions may have shape with indexes for (example, class) or for (example,
         # random_sample, class).  We'll make the latter look like the former.
         predictions = predictions.reshape((-1, predictions.shape[-1]))
-        negative_entropy_score: NDArray[np.float_] = -scipy.stats.entropy(
-            predictions, axis=-1
-        )
+        negative_entropy_score: NDArray[np.float_]
+        negative_entropy_score = -scipy.stats.entropy(predictions, axis=-1)
         # Find second highest and highest scoring classes
         margin_argsort: NDArray[np.int_] = np.argpartition(predictions, -2, axis=-1)
         prediction_indices: NDArray[np.int_] = np.arange(len(predictions))
         confidence_score: NDArray[np.float_]
         confidence_score = predictions[prediction_indices, margin_argsort[:, -1]]
-        margin_score: NDArray[np.float_] = (
+        margin_score: NDArray[np.float_]
+        margin_score = (
             confidence_score - predictions[prediction_indices, margin_argsort[:, -2]]
         )
 
@@ -832,7 +832,8 @@ class _TensorFlow(_AbstractPlatform):
             optimizer="adam", loss=self.loss_function, metrics=["accuracy"]
         )
 
-        validation_args: Mapping[str, Any] = (
+        validation_args: Mapping[str, Any]
+        validation_args = (
             dict()
             if len(validation_features) == 0
             else {"validation_data": (validation_features, validation_labels)}
@@ -857,7 +858,8 @@ class _TensorFlow(_AbstractPlatform):
         """
 
         if log_it:
-            predictions: NDArray[np.float_] = self.model.predict(
+            predictions: NDArray[np.float_]
+            predictions = self.model.predict(
                 features, verbose=0, callbacks=[self.logger]
             )
         else:
@@ -940,7 +942,8 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
         )
 
         if do_validation:
-            validation_features_labels: _PyTorch._ZipDataset = _PyTorch._ZipDataset(
+            validation_features_labels: _PyTorch._ZipDataset
+            validation_features_labels = _PyTorch._ZipDataset(
                 validation_features, validation_labels
             )
             # Note that DataLoader has additional parameters that we may wish to use in
@@ -1009,9 +1012,8 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
                         validation_correct += new_correct
                     val_loss: float = validation_loss / validation_size
                     val_accuracy: float = validation_correct / validation_size
-                    more_logs: Mapping[str, Any] = dict(
-                        val_loss=val_loss, val_accuracy=val_accuracy
-                    )
+                    more_logs: Mapping[str, Any]
+                    more_logs = dict(val_loss=val_loss, val_accuracy=val_accuracy)
                     logs = {**logs, **more_logs}
             self.logger.on_epoch_end(epoch, logs)
 
@@ -1089,7 +1091,8 @@ class SamplingBayesianPyTorchModelHandler(
         )
 
         if do_validation:
-            validation_features_labels: _PyTorch._ZipDataset = _PyTorch._ZipDataset(
+            validation_features_labels: _PyTorch._ZipDataset
+            validation_features_labels = _PyTorch._ZipDataset(
                 validation_features, validation_labels
             )
             # Note that DataLoader has additional parameters that we may wish to use in
@@ -1170,9 +1173,8 @@ class SamplingBayesianPyTorchModelHandler(
                         validation_correct += new_correct
                     val_loss: float = validation_loss / validation_size
                     val_accuracy: float = validation_correct / validation_size
-                    more_logs: Mapping[str, Any] = dict(
-                        val_loss=val_loss, val_accuracy=val_accuracy
-                    )
+                    more_logs: Mapping[str, Any]
+                    more_logs = dict(val_loss=val_loss, val_accuracy=val_accuracy)
                     logs = {**logs, **more_logs}
             self.logger.on_epoch_end(epoch, logs)
 

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -246,7 +246,7 @@ class _AbstractCommon:
         # invokes it for us, we cannot simply supply training_size through this
         # interface.  Instead we grab it from self.training_size and require that the
         # user has already set that to something reasonable.
-        def on_train_begin(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_train_begin(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -256,7 +256,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_train_end(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_train_end(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -266,7 +266,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_epoch_begin(self, epoch: int, logs: Mapping[str, Any] = dict()) -> None:
+        def on_epoch_begin(self, epoch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -277,7 +277,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_epoch_end(self, epoch: int, logs: Mapping[str, Any] = dict()) -> None:
+        def on_epoch_end(self, epoch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -288,9 +288,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_train_batch_begin(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_train_batch_begin(self, batch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -301,9 +299,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_train_batch_end(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_train_batch_end(self, batch: int, logs: Mapping[str, Any]) -> None:
             # For tensorflow, logs.keys() == ["loss", "accuracy"]
             self.append_to_log(
                 {
@@ -315,7 +311,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_test_begin(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_test_begin(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -325,7 +321,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_test_end(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_test_end(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -335,9 +331,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_test_batch_begin(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_test_batch_begin(self, batch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -348,9 +342,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_test_batch_end(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_test_batch_end(self, batch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -361,7 +353,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_predict_begin(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_predict_begin(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -371,7 +363,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_predict_end(self, logs: Mapping[str, Any] = dict()) -> None:
+        def on_predict_end(self, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -381,9 +373,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_predict_batch_begin(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_predict_batch_begin(self, batch: int, logs: Mapping[str, Any]) -> None:
             self.append_to_log(
                 {
                     "utcnow": datetime.utcnow(),
@@ -394,9 +384,7 @@ class _AbstractCommon:
                 }
             )
 
-        def on_predict_batch_end(
-            self, batch: int, logs: Mapping[str, Any] = dict()
-        ) -> None:
+        def on_predict_batch_end(self, batch: int, logs: Mapping[str, Any]) -> None:
             # For tensorflow, logs.keys() == ["outputs"]
             self.append_to_log(
                 {
@@ -930,7 +918,7 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
         # https://towardsdatascience.com/a-tale-of-two-frameworks-985fa7fcec.
 
         self.logger.training_size = train_features.shape[0]
-        self.logger.on_train_begin()
+        self.logger.on_train_begin(logs=dict())
 
         # Get `epochs` from training parameters!!!
         number_of_epochs: int = 10
@@ -959,13 +947,13 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
 
         # Loop over the dataset multiple times
         for epoch in range(number_of_epochs):
-            self.logger.on_epoch_begin(epoch)
+            self.logger.on_epoch_begin(epoch, logs=dict())
             train_loss: float = 0.0
             train_size: int = 0
             train_correct: float = 0.0
             self.model.train()  # What does this do?!!!
             for i, data in enumerate(my_train_data_loader):
-                self.logger.on_train_batch_begin(i)
+                self.logger.on_train_batch_begin(i, logs=dict())
                 inputs, labels = data
                 # zero the parameter gradients
                 optimizer.zero_grad()
@@ -1033,7 +1021,7 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
         import torch
 
         if log_it:
-            self.logger.on_predict_begin()
+            self.logger.on_predict_begin(logs=dict())
         with torch.no_grad():
             self.model.eval()  # What does this do?!!!
             # Use non_blocking=True in the self.model call!!!
@@ -1083,7 +1071,7 @@ class SamplingBayesianPyTorchModelHandler(
         do_validation: bool = len(validation_features) != 0
 
         self.logger.training_size = train_features.shape[0]
-        self.logger.on_train_begin()
+        self.logger.on_train_begin(logs=dict())
 
         # Get `epochs` from training parameters!!!
         number_of_epochs: int = 10
@@ -1115,12 +1103,12 @@ class SamplingBayesianPyTorchModelHandler(
         num_validation_samples: int = 1
         # Loop over the dataset multiple times
         for epoch in range(number_of_epochs):
-            self.logger.on_epoch_begin(epoch)
+            self.logger.on_epoch_begin(epoch, logs=dict())
             train_loss: float = 0.0
             train_size: int = 0
             train_correct: float = 0.0
             for i, data in enumerate(my_train_data_loader):
-                self.logger.on_train_batch_begin(i)
+                self.logger.on_train_batch_begin(i, logs=dict())
                 inputs, labels = data
                 # zero the parameter gradients
                 optimizer.zero_grad()
@@ -1200,7 +1188,7 @@ class SamplingBayesianPyTorchModelHandler(
         # Instead, get `num_predict_samples` from somewhere!!!
         num_predict_samples = 100
         if log_it:
-            self.logger.on_predict_begin()
+            self.logger.on_predict_begin(logs=dict())
         # For this Bayesian model, torch is expecting a channels==1 dimension at
         # shape[1].  Why?!!!
         features = np.expand_dims(features, 1)

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -187,7 +187,8 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         pass
 
         # These parameters must be supplied to the set_learning_parameters call.
-        self.required_parameters_keys: List[str] = [
+        self.required_parameters_keys: List[str]
+        self.required_parameters_keys = [
             "label_of_interest",
             "maximum_queries",
             "number_to_select_per_query",
@@ -361,7 +362,8 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         validation_labels = self.dataset_handler.get_validation_labels()
         if len(validation_labels.shape) == 1:
             validation_labels = validation_labels[:, np.newaxis]
-        validation_args: List = (
+        validation_args: List
+        validation_args = (
             list()
             if len(validation_feature_vectors.shape) == 0
             else [validation_feature_vectors, validation_labels]
@@ -372,9 +374,8 @@ class GenericStrategyHandler(AbstractStrategyHandler):
 
         # Do initial training
         self.model_handler.reinitialize_weights()
-        current_feature_vectors: NDArray[np.float_] = feature_vectors[
-            labeled_indices, :
-        ]
+        current_feature_vectors: NDArray[np.float_]
+        current_feature_vectors = feature_vectors[labeled_indices, :]
         current_labels: NDArray[np.int_] = labels[labeled_indices, label_of_interest]
         if len(current_feature_vectors) > 0:
             print(f"Training with {current_feature_vectors.shape[0]} examples")
@@ -386,13 +387,13 @@ class GenericStrategyHandler(AbstractStrategyHandler):
         for query in range(maximum_queries):
             # Evaluate the pool of possibilities
             print(f"Predicting for {feature_vectors.shape[0]} examples")
-            self.predictions: NDArray[np.float_] = self.model_handler.predict(
-                feature_vectors, log_it=all_p
-            )
+            self.predictions: NDArray[np.float_]
+            self.predictions = self.model_handler.predict(feature_vectors, log_it=all_p)
             if not all_p:
                 # Log the predictions for the unlabeled examples only
                 unlabeled_indices: Set[int] = all_indices - set(labeled_indices)
-                unlabeled_predictions: NDArray[np.float_] = self.predictions[
+                unlabeled_predictions: NDArray[np.float_]
+                unlabeled_predictions = self.predictions[
                     np.fromiter(unlabeled_indices, dtype=np.int64)
                 ]
                 self.model_handler.get_logger().on_predict_end(
@@ -490,7 +491,8 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         examples with the smallest maximum score.
         """
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
-        number_of_feature_vectors: int = (
+        number_of_feature_vectors: int
+        number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
@@ -538,7 +540,8 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         examples with the smallest gap between highest and second-highest score.
         """
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
-        number_of_feature_vectors: int = (
+        number_of_feature_vectors: int
+        number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
@@ -560,7 +563,8 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         # Find the largest and second largest values, and compute their difference
         predict_indices: NDArray[np.int_] = np.arange(len(predictions))
         predict_argsort: NDArray[np.int_] = np.argsort(predictions, axis=-1)
-        predict_score: NDArray[np.float_] = (
+        predict_score: NDArray[np.float_]
+        predict_score = (
             predictions[predict_indices, predict_argsort[:, -1]]
             - predictions[predict_indices, predict_argsort[:, -2]]
         )
@@ -591,7 +595,8 @@ class MaximumEntropyStrategyHandler(GenericStrategyHandler):
         examples with the highest entropy.
         """
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
-        number_of_feature_vectors: int = (
+        number_of_feature_vectors: int
+        number_of_feature_vectors = (
             self.dataset_handler.get_all_feature_vectors().shape[0]
         )
 
@@ -667,7 +672,8 @@ class BatchBaldStrategyHandler(GenericStrategyHandler):
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
         # Use the subset of self.predictions that excludes labeled_indices and
         # validation_indices
-        available_indices: NDArray[np.int_] = np.fromiter(
+        available_indices: NDArray[np.int_]
+        available_indices = np.fromiter(
             set(range(self.predictions.shape[0]))
             - (set(labeled_indices) | set(validation_indices)),
             dtype=np.int64,

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import numpy as np
 import scipy.stats
 from numpy.typing import NDArray
-from typing import Dict, List, Mapping, Set
+from typing import List, Mapping, Set
 from . import dataset, model
 
 
@@ -307,7 +307,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             raise ValueError(
                 f"set_learning_parameters given invalid key(s): {invalid_keys}"
             )
-        self.parameters: Dict[str, str] = parameters
+        self.parameters: Mapping[str, str] = parameters
 
     def get_learning_parameters(self) -> Mapping:
         return self.parameters

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -296,13 +296,13 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 f" Python dict but is of type {type(parameters)}"
             )
 
-        missing_keys: Set = set(self.required_parameters_keys) - set(parameters)
+        missing_keys: Set[str] = set(self.required_parameters_keys) - set(parameters)
         if len(missing_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters missing required key(s): {missing_keys}"
             )
 
-        invalid_keys: Set = set(parameters) - set(self.valid_parameters_keys)
+        invalid_keys: Set[str] = set(parameters) - set(self.valid_parameters_keys)
         if len(invalid_keys) > 0:
             raise ValueError(
                 f"set_learning_parameters given invalid key(s): {invalid_keys}"
@@ -382,14 +382,16 @@ class GenericStrategyHandler(AbstractStrategyHandler):
                 current_feature_vectors, current_labels, *validation_args
             )
         # Loop through the queries
-        all_indices: Set = set(range(len(feature_vectors)))
+        all_indices: Set[int] = set(range(len(feature_vectors)))
         for query in range(maximum_queries):
             # Evaluate the pool of possibilities
             print(f"Predicting for {feature_vectors.shape[0]} examples")
-            self.predictions = self.model_handler.predict(feature_vectors, log_it=all_p)
+            self.predictions: NDArray[np.float_] = self.model_handler.predict(
+                feature_vectors, log_it=all_p
+            )
             if not all_p:
                 # Log the predictions for the unlabeled examples only
-                unlabeled_indices: Set = all_indices - set(labeled_indices)
+                unlabeled_indices: Set[int] = all_indices - set(labeled_indices)
                 unlabeled_predictions: NDArray[np.float_] = self.predictions[
                     np.fromiter(unlabeled_indices, dtype=np.int64)
                 ]
@@ -451,7 +453,7 @@ class RandomStrategyHandler(GenericStrategyHandler):
         feature_vectors = self.dataset_handler.get_all_feature_vectors()
 
         # Make sure the pool to select from is large enough
-        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
+        excluded_indices: Set[int] = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > feature_vectors.shape[0]:
             raise ValueError(
                 f"Cannot select {number_to_select} unlabeled feature vectors; only"
@@ -493,7 +495,7 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
+        excluded_indices: Set[int] = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot select {number_to_select} unlabeled feature vectors; only"
@@ -508,7 +510,7 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
         # Probably they also already sum to 1.0, but let's force that anyway.
         predictions = predictions / predictions.sum(axis=-1, keepdims=True)
         # For each example, how strong is the best category's score?
-        predict_score = np.amax(predictions, axis=-1)
+        predict_score: NDArray[np.float_] = np.amax(predictions, axis=-1)
         # Make the currently labeled examples look confident, so that they won't be
         # selected
         if len(excluded_indices):
@@ -541,7 +543,7 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
+        excluded_indices: Set[int] = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot select {number_to_select} unlabeled feature vectors; only"
@@ -594,7 +596,7 @@ class MaximumEntropyStrategyHandler(GenericStrategyHandler):
         )
 
         # Make sure the pool to select from is large enough
-        excluded_indices: Set = set(labeled_indices) | set(validation_indices)
+        excluded_indices: Set[int] = set(labeled_indices) | set(validation_indices)
         if number_to_select + len(excluded_indices) > number_of_feature_vectors:
             raise ValueError(
                 f"Cannot select {number_to_select} unlabeled feature vectors; only"

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import numpy as np
 import scipy.stats
 from numpy.typing import NDArray
-from typing import List, Mapping, Set
+from typing import List, Mapping, Optional, Set
 from . import dataset, model
 
 
@@ -132,7 +132,7 @@ class AbstractStrategyHandler:
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         raise NotImplementedError(
             "Abstract method AbstractStrategyHandler::select_next_indices"
@@ -316,7 +316,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         raise NotImplementedError(
             "Abstract method GenericStrategyHandler::select_next_indices should not"
@@ -384,7 +384,7 @@ class GenericStrategyHandler(AbstractStrategyHandler):
             )
         # Loop through the queries
         all_indices: Set[int] = set(range(len(feature_vectors)))
-        for query in range(maximum_queries):
+        for _ in range(maximum_queries):
             # Evaluate the pool of possibilities
             print(f"Predicting for {feature_vectors.shape[0]} examples")
             self.predictions: NDArray[np.float_]
@@ -438,7 +438,7 @@ class RandomStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.
@@ -449,6 +449,8 @@ class RandomStrategyHandler(GenericStrategyHandler):
           examples, including both those examples that have been labeled and those that
           could be selected for labeling.
         """
+        if validation_indices is None:
+            validation_indices = np.array((), dtype=np.int64)
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
         feature_vectors: NDArray[np.float_]
         feature_vectors = self.dataset_handler.get_all_feature_vectors()
@@ -484,12 +486,14 @@ class LeastConfidenceStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest maximum score.
         """
+        if validation_indices is None:
+            validation_indices = np.array((), dtype=np.int64)
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
         number_of_feature_vectors: int
         number_of_feature_vectors = (
@@ -533,12 +537,14 @@ class LeastMarginStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the smallest gap between highest and second-highest score.
         """
+        if validation_indices is None:
+            validation_indices = np.array((), dtype=np.int64)
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
         number_of_feature_vectors: int
         number_of_feature_vectors = (
@@ -588,12 +594,14 @@ class MaximumEntropyStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
         examples with the highest entropy.
         """
+        if validation_indices is None:
+            validation_indices = np.array((), dtype=np.int64)
         number_to_select: int = int(self.parameters["number_to_select_per_query"])
         number_of_feature_vectors: int
         number_of_feature_vectors = (
@@ -639,7 +647,7 @@ class BaldStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.  This choses the unlabeled
@@ -658,12 +666,14 @@ class BatchBaldStrategyHandler(GenericStrategyHandler):
     def select_next_indices(
         self,
         labeled_indices: NDArray[np.int_],
-        validation_indices: NDArray[np.int_] = np.array((), dtype=np.int64),
+        validation_indices: Optional[NDArray[np.int_]] = None,
     ) -> NDArray[np.int_]:
         """
         Select new examples to be labeled by the expert.  This chooses the unlabeled
         examples based upon the Batch-BALD criterion.  (See also BaldStrategyHandler.)
         """
+        if validation_indices is None:
+            validation_indices = np.array((), dtype=np.int64)
         import torch
         import batchbald_redux as bbald
         import batchbald_redux.batchbald

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
 dynamic = ["version", "description"]
 
 # [project.optional-dependencies]
-# torch = ["torch>=1.11<2.0"]
-# tensorflow = ["tensorflow>=2.6<3.0"]
+# torch = ["torch>=1.11,<2.0"]
+# tensorflow = ["tensorflow>=2.6,<3.0"]
 
 [project.urls]
 Source = "https://github.com/DigitalSlideArchive/ALBench"

--- a/scripts/FeatureExtraction.py
+++ b/scripts/FeatureExtraction.py
@@ -567,7 +567,7 @@ def main(args):  # noqa: C901
     else:
         print("Fitting PCA ... ")
         df = pd.DataFrame(
-            data=slide_superpixel_data, columns=[_ for _ in range(args.fcn)]
+            data=slide_superpixel_data, columns=(_ for _ in range(args.fcn))
         )
         df_sample = df.reindex(np.random.permutation(df.index)).sample(
             frac=args.pca_sample_scale

--- a/test/check.py
+++ b/test/check.py
@@ -32,7 +32,7 @@ def check_deeply_numeric(x: Any) -> bool:
         isinstance(x, np.ndarray)
         and (
             (len(x.shape) == 0 and check_deeply_numeric(x[()]))
-            or (len(x.shape) > 0 and all([check_deeply_numeric(e) for e in x]))
+            or (len(x.shape) > 0 and all(check_deeply_numeric(e) for e in x))
         )
     )
 
@@ -52,14 +52,12 @@ def deeply_allclose(a: Any, b: Any, rtol=1e-05, atol=1e-08, equal_nan=False) -> 
         if isinstance(a, str)
         else len(a) == len(b)
         and all(
-            [
-                deeply_allclose(elem_a, elem_b, rtol, atol, equal_nan)
-                for elem_a, elem_b in zip(a, b)
-            ]
+            deeply_allclose(elem_a, elem_b, rtol, atol, equal_nan)
+            for elem_a, elem_b in zip(a, b)
         )
         if isinstance(a, (list, tuple, set))
         else deeply_allclose(set(a.keys()), set(b.keys()), rtol, atol, equal_nan)
-        and all([deeply_allclose(a[k], b[k], rtol, atol, equal_nan) for k in a.keys()])
+        and all(deeply_allclose(a[k], b[k], rtol, atol, equal_nan) for k in a.keys())
         if isinstance(a, dict)
         else False
     )

--- a/test/check.py
+++ b/test/check.py
@@ -38,7 +38,8 @@ def check_deeply_numeric(x: Any) -> bool:
 
 
 def deeply_allclose(a: Any, b: Any, rtol=1e-05, atol=1e-08, equal_nan=False) -> bool:
-    response: bool = (
+    response: bool
+    response = (
         isinstance(b, (int, float, np.int32, np.int64, np.float32, np.float64))
         and np.allclose(a, b, rtol, atol, equal_nan)
         if (isinstance(a, (int, float, np.int32, np.int64, np.float32, np.float64)))

--- a/test/create.py
+++ b/test/create.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 import numpy as np
 from check import NDArrayFloat, NDArrayInt, SequenceFloat, SequenceInt
-from typing import Dict, List, Optional, Tuple
+from typing import Mapping, List, Optional, Tuple
 
 
 def create_dataset(
@@ -27,7 +27,7 @@ def create_dataset(
     number_of_features: int,
     number_of_categories_by_label: List[int],
     **kwargs,
-) -> Tuple[NDArrayFloat, List[Dict], NDArrayInt]:
+) -> Tuple[NDArrayFloat, List[Mapping], NDArrayInt]:
     """
     Create a toy set of feature vectors
     """
@@ -38,7 +38,7 @@ def create_dataset(
 
     # Note that apparently TensorFlow requires that the labels be consecutive integers
     # starting with zero.  So, we will use -1 for "unknown".
-    my_label_definitions: List[Dict] = [
+    my_label_definitions: List[Mapping] = [
         {
             -1: {"description": f"Label{label_index}Unknown"},
             **{
@@ -76,7 +76,7 @@ def create_dataset_4598_1280_4(
     number_of_features: int,
     number_of_categories_by_label: int,
     **kwargs,
-) -> Tuple[NDArrayFloat, List[Dict], NDArrayInt]:
+) -> Tuple[NDArrayFloat, List[Mapping], NDArrayInt]:
     import h5py as h5
 
     """Use the dataset from test/TCGA-A2-A0D0-DX1_xmin68482_ymin39071_MPP-0.2500.h5py"""
@@ -84,7 +84,7 @@ def create_dataset_4598_1280_4(
     with h5.File(filename) as ds:
         my_feature_vectors: NDArrayFloat = np.array(ds["features"])
         my_labels: NDArrayInt = np.array(ds["labels"])
-    my_label_definitions: List[Dict] = [
+    my_label_definitions: List[Mapping] = [
         {
             0: {"description": "other"},
             1: {"description": "tumor"},

--- a/test/create.py
+++ b/test/create.py
@@ -32,13 +32,15 @@ def create_dataset(
     Create a toy set of feature vectors
     """
     rng = np.random.default_rng()
-    my_feature_vectors: NDArrayFloat = rng.normal(
+    my_feature_vectors: NDArrayFloat
+    my_feature_vectors = rng.normal(
         0, 1, size=(number_of_superpixels, number_of_features)
     ).astype(np.float64)
 
     # Note that apparently TensorFlow requires that the labels be consecutive integers
     # starting with zero.  So, we will use -1 for "unknown".
-    my_label_definitions: List[Mapping] = [
+    my_label_definitions: List[Mapping]
+    my_label_definitions = [
         {
             -1: {"description": f"Label{label_index}Unknown"},
             **{
@@ -55,7 +57,8 @@ def create_dataset(
 
     # Create a random label for each superpixel.  Avoid -1, which we are using for
     # "unknown".
-    my_labels: NDArrayInt = np.concatenate(
+    my_labels: NDArrayInt
+    my_labels = np.concatenate(
         [
             np.array(
                 np.clip(
@@ -84,7 +87,8 @@ def create_dataset_4598_1280_4(
     with h5.File(filename) as ds:
         my_feature_vectors: NDArrayFloat = np.array(ds["features"])
         my_labels: NDArrayInt = np.array(ds["labels"])
-    my_label_definitions: List[Mapping] = [
+    my_label_definitions: List[Mapping]
+    my_label_definitions = [
         {
             0: {"description": "other"},
             1: {"description": "tumor"},
@@ -279,7 +283,8 @@ def create_dirichlet_predictions(
         num_repeats = 1
 
     predictions: NDArrayFloat = np.zeros((num_samples, num_repeats, num_classes))
-    sample_pseudocounts: NDArrayFloat = rng_gamma(
+    sample_pseudocounts: NDArrayFloat
+    sample_pseudocounts = rng_gamma(
         alpha=alpha_hyperprior,
         beta=beta_hyperprior,
         shape=(num_samples, num_classes),

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -27,7 +27,8 @@ def test_0010_dataset_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Mapping[str, Any] = {
+    parameters: Mapping[str, Any]
+    parameters = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 import al_bench as alb
 import al_bench.dataset
 from exercise import exercise_dataset_handler
-from typing import Any, Dict, Type
+from typing import Any, Mapping, Type
 
 
 def test_0010_dataset_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Dict[str, Any] = {
+    parameters: Mapping[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -27,7 +27,8 @@ def test_0020_model_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Mapping[str, Any] = {
+    parameters: Mapping[str, Any]
+    parameters = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 import al_bench as alb
 import al_bench.model
 from exercise import exercise_model_handler
-from typing import Any, Dict, Type
+from typing import Any, Mapping, Type
 
 
 def test_0020_model_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Dict[str, Any] = {
+    parameters: Mapping[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 import al_bench as alb
 import al_bench.strategy
 from exercise import exercise_strategy_handler
-from typing import Any, Dict, Type
+from typing import Any, Mapping, Type
 
 
 def test_0030_strategy_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Dict[str, Any] = {
+    parameters: Mapping[str, Any] = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -27,7 +27,8 @@ def test_0030_strategy_handler_interface() -> None:
     """Purpose: Test that high-level operations work"""
 
     # Specify some testing parameters
-    parameters: Mapping[str, Any] = {
+    parameters: Mapping[str, Any]
+    parameters = {
         "number_of_superpixels": 1000,
         "number_of_features": 2048,
         "number_of_categories_by_label": [5, 7],

--- a/test/test_0040_factory.py
+++ b/test/test_0040_factory.py
@@ -216,19 +216,14 @@ def test_0040_factory() -> None:
         or key in certainty_type
     }
     assert all(
-        [
-            output[key0][key1] == expected_output[key0][key1]
-            for key0 in expected_output_keys | output.keys()
-            for key1 in expected_output[key0].keys() | output[key0].keys()
-            if key1 != "scores"
-        ]
+        output[key0][key1] == expected_output[key0][key1]
+        for key0 in expected_output_keys | output.keys()
+        for key1 in expected_output[key0].keys() | output[key0].keys()
+        if key1 != "scores"
     )
     assert all(
-        [
-            ((output[key]["scores"] - expected_output[key]["scores"]) ** 2).sum()
-            < 1e-12
-            for key in expected_output_keys | output.keys()
-        ]
+        ((output[key]["scores"] - expected_output[key]["scores"]) ** 2).sum() < 1e-12
+        for key in expected_output_keys | output.keys()
     )
 
 

--- a/test/test_0040_factory.py
+++ b/test/test_0040_factory.py
@@ -59,7 +59,8 @@ def test_0040_factory() -> None:
         certainty_type, percentiles, cutoffs
     )
     # Create dummy input for testing
-    predictions: NDArrayFloat = np.array(
+    predictions: NDArrayFloat
+    predictions = np.array(
         [
             [
                 [6.32163380, 3.41019114, 3.30049889, 2.06819065, 1.52704675],

--- a/test/test_0050_factory.py
+++ b/test/test_0050_factory.py
@@ -113,8 +113,7 @@ def test_0050_factory() -> None:
         print("import numpy as np")
         print(f"expected_certainties = {deep_print(certainties)}")
         cutoffs = {
-            k: [cut for cut in v["percentiles"].values()]
-            for k, v in expected_certainties.items()
+            k: list(v["percentiles"].values()) for k, v in expected_certainties.items()
         }
         print(f"best_cutoffs = {deep_print(cutoffs)}")
 

--- a/test/test_0050_factory.py
+++ b/test/test_0050_factory.py
@@ -66,9 +66,8 @@ def test_0050_factory() -> None:
         percentiles=percentiles,
         cutoffs=cutoffs,
     )
-    certainties: Mapping[str, Mapping[str, Any]] = compute_certainty.from_numpy_array(
-        predictions
-    )
+    certainties: Mapping[str, Mapping[str, Any]]
+    certainties = compute_certainty.from_numpy_array(predictions)
 
     # Note that applying np.argsort twice produces integers in the same order as the
     # original input.

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -28,7 +28,7 @@ from check import check_deeply_numeric, NDArrayFloat, NDArrayInt
 from create import create_dataset_4598_1280_4
 from create import create_pytorch_model_with_dropout
 from create import create_tensorflow_model_with_dropout
-from typing import Any, Dict, List, Match, Optional, Type
+from typing import Any, Mapping, List, Match, Optional, Type
 
 
 def test_0100_handler_combinations() -> None:
@@ -50,7 +50,7 @@ def test_0100_handler_combinations() -> None:
     """
 
     # Specify some testing parameters
-    parameters: Dict[str, Any] = {
+    parameters: Mapping[str, Any] = {
         "number_of_superpixels": 4598,
         "number_of_features": 1280,
         "number_of_categories_by_label": [4],
@@ -90,7 +90,7 @@ def test_0100_handler_combinations() -> None:
             ):
                 # Create fresh handlers and components
                 my_feature_vectors: NDArrayFloat
-                my_label_definitions: List[Dict]
+                my_label_definitions: List[Mapping]
                 my_labels: NDArrayInt
                 my_feature_vectors, my_label_definitions, my_labels = dataset_creator(
                     **parameters

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -178,18 +178,14 @@ def test_0100_handler_combinations() -> None:
                 ################
                 my_log: List = my_strategy_handler.get_log()
                 assert isinstance(my_log, list)
-                assert all([isinstance(e, dict) for e in my_log])
-                assert all([isinstance(e["utcnow"], datetime.datetime) for e in my_log])
+                assert all(isinstance(e, dict) for e in my_log)
+                assert all(isinstance(e["utcnow"], datetime.datetime) for e in my_log)
                 assert all(
-                    [isinstance(e["model_step"], alb.model.ModelStep) for e in my_log]
+                    isinstance(e["model_step"], alb.model.ModelStep) for e in my_log
                 )
-                assert all([isinstance(e["logs"], dict) for e in my_log])
+                assert all(isinstance(e["logs"], dict) for e in my_log)
                 assert all(
-                    [
-                        check_deeply_numeric(v)
-                        for e in my_log
-                        for v in e["logs"].values()
-                    ]
+                    check_deeply_numeric(v) for e in my_log for v in e["logs"].values()
                 )
                 my_strategy_handler.write_train_log_for_tensorboard(
                     log_dir=os.path.join("runs", combination_name)

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -50,7 +50,8 @@ def test_0100_handler_combinations() -> None:
     """
 
     # Specify some testing parameters
-    parameters: Mapping[str, Any] = {
+    parameters: Mapping[str, Any]
+    parameters = {
         "number_of_superpixels": 4598,
         "number_of_features": 1280,
         "number_of_categories_by_label": [4],
@@ -95,9 +96,8 @@ def test_0100_handler_combinations() -> None:
                 my_feature_vectors, my_label_definitions, my_labels = dataset_creator(
                     **parameters
                 )
-                my_dataset_handler: alb.dataset.AbstractDatasetHandler = (
-                    DatasetHandler()
-                )
+                my_dataset_handler: alb.dataset.AbstractDatasetHandler
+                my_dataset_handler = DatasetHandler()
                 my_dataset_handler.set_all_feature_vectors(my_feature_vectors)
                 my_dataset_handler.set_all_label_definitions(my_label_definitions)
                 my_dataset_handler.set_all_labels(my_labels)
@@ -114,9 +114,8 @@ def test_0100_handler_combinations() -> None:
                 my_model_handler: alb.model.AbstractModelHandler = ModelHandler()
                 my_model_handler.set_model(my_model)
 
-                my_strategy_handler: alb.strategy.AbstractStrategyHandler = (
-                    StrategyHandler()
-                )
+                my_strategy_handler: alb.strategy.AbstractStrategyHandler
+                my_strategy_handler = StrategyHandler()
                 my_strategy_handler.set_dataset_handler(my_dataset_handler)
                 my_strategy_handler.set_model_handler(my_model_handler)
                 my_strategy_handler.set_learning_parameters(
@@ -128,33 +127,40 @@ def test_0100_handler_combinations() -> None:
                 # Start with nothing labeled yet
                 currently_labeled_examples: NDArrayInt = np.array((), dtype=np.int64)
 
-                # dataset_match: Optional[Match[str]] = re.search(
+                # dataset_match: Optional[Match[str]]
+                # dataset_match = re.search(
                 #     r"<class 'al_bench\.dataset\.(.*)'>",
                 #     f"{type(my_dataset_handler)}",
                 # )
-                # dataset_string: str = (
+                # dataset_string: str
+                # dataset_string = (
                 #     "dataset_handler_NOT_FOUND"
                 #     if dataset_match is None
                 #     else dataset_match.group(1)
                 # )
-                model_match: Optional[Match[str]] = re.search(
+                model_match: Optional[Match[str]]
+                model_match = re.search(
                     r"<class 'al_bench\.model\.(.*)'>", f"{type(my_model_handler)}"
                 )
-                model_string: str = (
+                model_string: str
+                model_string = (
                     "model_handler_NOT_FOUND"
                     if model_match is None
                     else model_match.group(1)
                 )
-                strategy_match: Optional[Match[str]] = re.search(
+                strategy_match: Optional[Match[str]]
+                strategy_match = re.search(
                     r"<class 'al_bench\.strategy\.(.*)'>",
                     f"{type(my_strategy_handler)}",
                 )
-                strategy_string: str = (
+                strategy_string: str
+                strategy_string = (
                     "strategy_handler_NOT_FOUND"
                     if strategy_match is None
                     else strategy_match.group(1)
                 )
-                combination_name: str = "-".join(
+                combination_name: str
+                combination_name = "-".join(
                     [
                         # dataset_string,
                         model_string,

--- a/test/test_0120_bayesian_model.py
+++ b/test/test_0120_bayesian_model.py
@@ -85,9 +85,8 @@ def test_0120_bayesian_model() -> None:
     dataset_list = train_dataset_list + test_dataset_list
     # Unzip the data set into separate (unlabeled) input data and their labels.  Data
     # only:
-    my_feature_vectors: NDArrayFloat = np.concatenate(
-        [d[0].numpy() for d in dataset_list]
-    )
+    my_feature_vectors: NDArrayFloat
+    my_feature_vectors = np.concatenate([d[0].numpy() for d in dataset_list])
 
     # Each is list of one label only:
     my_labels: NDArrayInt = np.array([[d[1]] for d in dataset_list])

--- a/test/test_0120_bayesian_model.py
+++ b/test/test_0120_bayesian_model.py
@@ -28,7 +28,7 @@ import random
 import shutil
 import torch
 from check import NDArrayFloat, NDArrayInt
-from typing import Dict, List, Tuple
+from typing import Mapping, List, Tuple
 
 
 class BayesianCNN(bbald.consistent_mc_dropout.BayesianModule):
@@ -95,7 +95,7 @@ def test_0120_bayesian_model() -> None:
     # values 0 through 9.
     num_classes: int = 10
     # We have one label per feature_vector so we need a list of one dictionary.
-    my_label_definitions: List[Dict[int, Dict[str, str]]]
+    my_label_definitions: List[Mapping[int, Mapping[str, str]]]
     my_label_definitions = [{i: {"description": repr(i)} for i in range(num_classes)}]
     # We will indicate the validation examples by their indices.
     validation_indices: NDArrayInt

--- a/test/test_0120_bayesian_model.py
+++ b/test/test_0120_bayesian_model.py
@@ -76,9 +76,9 @@ def test_0120_bayesian_model() -> None:
     # al_bench datasets are supplied as numpy arrays.
     # Build the numpy arrays from a subset of the data
     train_dataset_list: List[Tuple[torch.Tensor, int]]
-    train_dataset_list = random.sample([d for d in train_dataset], 500)
+    train_dataset_list = random.sample(list(train_dataset), 500)
     test_dataset_list: List[Tuple[torch.Tensor, int]]
-    test_dataset_list = random.sample([d for d in test_dataset], 50)
+    test_dataset_list = random.sample(list(test_dataset), 50)
     num_training_indices: int = len(train_dataset_list)
     num_validation_indices: int = len(test_dataset_list)
     dataset_list: List[Tuple[torch.Tensor, int]]


### PR DESCRIPTION
With the goal of making it easier to detect when errors are introduced with future code changes:
* Adding types for additional variables and parameters.
* Making `mypy` and `tox` / `ruff` complain less about the code.

Also, minor performance improvements like:
* Invoking `all(my_generator)` rather than via list: `all(list(my_generator))` or `all([x for x in my_geneator])`.
* Invoking `dict(zip(keys, values))` rather than `{key: value for key, value in zip(keys, values)}`