### PR TITLE
BUG: Allow tuples instead of lists

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -455,14 +455,17 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         Set the entire database of dictionaries -- one per feature vector -- from a
         supplied list of Python dict objects.
 
-        N.B. if we were handed a (read-only) tuple then we cannot change a subset of
-        them.  If this functionality is needed then supply `list(dictionaries)` to this
-        function.
+        N.B. if we store a (read-only) tuple of dictionaries then we cannot change a
+        subset of them, so we convert any such tuple to a list.
         """
-        if isinstance(dictionaries, list) and all(
+        if isinstance(dictionaries, (list, tuple)) and all(
             isinstance(e, dict) for e in dictionaries
         ):
-            self.dictionaries: List[Mapping] = dictionaries
+            self.dictionaries: List[Mapping] = (
+                dictionaries.copy()
+                if isinstance(dictionaries, list)
+                else list(dictionaries)
+            )
         else:
             raise ValueError(
                 "The argument to set_all_dictionaries must be a list of Python"
@@ -524,16 +527,7 @@ class GenericDatasetHandler(AbstractDatasetHandler):
         use dictionary_indices=5, dictionaries={'a': 1, 'b': 2} OR use
         dictionary_indices=[5], dictionaries=[{'a': 1, 'b': 2}].
 
-        N.B. This will fail if the intially supplied value for dictionaries was a
-        *tuple* of dictionaries rather than a *list* of dictionaries, because tuples are
-        read-only.
         """
-        if isinstance(self.dictionaries, tuple):
-            raise ValueError(
-                "set_some_dictionaries cannot be used unless the initially supplied"
-                " dictionaries are supplied in a list instead of a tuple"
-            )
-
         for k, v in zip(dictionary_indices, dictionaries):
             self.dictionaries[k] = v
 
@@ -571,10 +565,14 @@ class GenericDatasetHandler(AbstractDatasetHandler):
             }
         """
 
-        if isinstance(label_definitions, list) and all(
+        if isinstance(label_definitions, (list, tuple)) and all(
             isinstance(e, dict) for e in label_definitions
         ):
-            self.label_definitions: List[Mapping] = label_definitions
+            self.label_definitions: List[Mapping] = (
+                label_definitions.copy()
+                if isinstance(label_definitions, list)
+                else list(label_definitions)
+            )
         else:
             raise ValueError(
                 "The argument to set_all_label_definitions must be a list of Python"

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -67,7 +67,7 @@ class ComputeCertainty:
 
         if cutoffs is None:
             cutoffs = {}
-        if len(certainty_type) == 1 and isinstance(cutoffs, list):
+        if len(certainty_type) == 1 and isinstance(cutoffs, (list, tuple)):
             cutoffs = {certainty_type[0]: cutoffs}
         # If we have no information for a certainty type, default to no cutoffs.
         cutoffs = {**{k: [] for k in certainty_type}, **cutoffs}

--- a/test/create.py
+++ b/test/create.py
@@ -77,7 +77,7 @@ def create_dataset(
 def create_dataset_4598_1280_4(
     number_of_superpixels: int,
     number_of_features: int,
-    number_of_categories_by_label: int,
+    number_of_categories_by_label,
     **kwargs,
 ) -> Tuple[NDArrayFloat, List[Mapping], NDArrayInt]:
     import h5py as h5
@@ -98,7 +98,7 @@ def create_dataset_4598_1280_4(
     ]
     assert number_of_superpixels == my_feature_vectors.shape[0]
     assert number_of_features == my_feature_vectors.shape[1]
-    assert isinstance(number_of_categories_by_label, list)
+    assert isinstance(number_of_categories_by_label, (list, tuple))
     assert len(number_of_categories_by_label) == len(my_label_definitions)
     assert number_of_categories_by_label[0] == len(my_label_definitions[0])
 


### PR DESCRIPTION
The code keeps some lists supplied by the user for later modification.  Instead of rejecting tuples supplied by the user, convert them to lists so that individual elements may later be modified.  Also, in the case that the user supplies a list, keep a shallow copy of it rather than the original, thus mimicking the behavior that we have for supplied tuples.

Closes #55.