### PR TITLE
Use `isort` to arrange imports

### DIFF
--- a/al_bench/dataset.py
+++ b/al_bench/dataset.py
@@ -17,10 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Iterable, List, Mapping, Set
+
 import h5py as h5
 import numpy as np
 from numpy.typing import NDArray
-from typing import Iterable, List, Mapping, Set
 
 
 class AbstractDatasetHandler:

--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -17,10 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Sequence
+
 import numpy as np
 import scipy.stats
 from numpy.typing import NDArray
-from typing import Any, Dict, List, Mapping, Sequence
 
 
 class ComputeCertainty:

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -951,7 +951,7 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
             train_loss: float = 0.0
             train_size: int = 0
             train_correct: float = 0.0
-            self.model.train()  # What does this do?!!!
+            self.model.train()  # Tell torch that we will be doing training
             for i, data in enumerate(my_train_data_loader):
                 self.logger.on_train_batch_begin(i, logs=dict())
                 inputs, labels = data
@@ -988,7 +988,7 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
                 validation_size: int = 0
                 validation_correct: float = 0.0
                 with torch.no_grad():
-                    self.model.eval()  # What does this do?!!!
+                    self.model.eval()  # Tell torch that we will be doing predictions
                     for data in my_validation_data_loader:
                         inputs, labels = data
                         # Use non_blocking=True in the self.model call!!!
@@ -1023,7 +1023,7 @@ class PyTorchModelHandler(_Common, _NonBayesian, _PyTorch, AbstractModelHandler)
         if log_it:
             self.logger.on_predict_begin(logs=dict())
         with torch.no_grad():
-            self.model.eval()  # What does this do?!!!
+            self.model.eval()  # Tell torch that we will be doing predictions
             # Use non_blocking=True in the self.model call!!!
             predictions_raw = self.model(torch.from_numpy(features))
             predictions: NDArray[np.float_] = predictions_raw.detach().cpu().numpy()
@@ -1067,7 +1067,7 @@ class SamplingBayesianPyTorchModelHandler(
         assert not np.any(np.isnan(train_features))
         assert not np.any(np.isnan(train_labels))
         assert (len(validation_features) == 0) == (len(validation_labels) == 0)
-        self.model.train()  # What does this do?!!!
+        self.model.train()  # Tell torch that we will be doing training
         do_validation: bool = len(validation_features) != 0
 
         self.logger.training_size = train_features.shape[0]
@@ -1145,7 +1145,7 @@ class SamplingBayesianPyTorchModelHandler(
                 validation_size = 0
                 validation_correct = 0.0
                 with torch.no_grad():
-                    self.model.eval()  # What does this do?!!!
+                    self.model.eval()  # Tell torch that we will be doing predictions
                     for data in my_validation_data_loader:
                         inputs, labels = data
                         # Use non_blocking=True in the self.model call!!!
@@ -1193,7 +1193,7 @@ class SamplingBayesianPyTorchModelHandler(
         # shape[1].  Why?!!!
         features = np.expand_dims(features, 1)
         with torch.no_grad():
-            self.model.eval()  # What does this do?!!!
+            self.model.eval()  # Tell torch that we will be doing predictions
             # Use non_blocking=True in the self.model call!!!
             predictions_raw = self.model(
                 torch.from_numpy(features), num_predict_samples

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -17,14 +17,16 @@
 # ==========================================================================
 
 from __future__ import annotations
+
 import copy
 import enum
 import math
+from datetime import datetime
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, cast
+
 import numpy as np
 import scipy.stats
-from datetime import datetime
 from numpy.typing import NDArray
-from typing import cast, Any, List, Mapping, Optional, Sequence, Tuple
 
 
 class ModelStep(enum.Enum):

--- a/al_bench/strategy.py
+++ b/al_bench/strategy.py
@@ -17,10 +17,13 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import List, Mapping, Optional, Set
+
 import numpy as np
 import scipy.stats
 from numpy.typing import NDArray
-from typing import List, Mapping, Optional, Set
+
 from . import dataset, model
 
 

--- a/scripts/FeatureExtraction.py
+++ b/scripts/FeatureExtraction.py
@@ -42,32 +42,27 @@ python FeatureExtraction.py --projectName path/to/myproject --superpixelSize 64 
 
 """
 
-import os
 import json
-import h5py
+import logging
+import os
 import time
 
-import pandas as pd
+import h5py
+import joblib  # was: from sklearn.externals import joblib
 import numpy as np
+import pandas as pd
+from keras import applications
+from keras.applications.vgg16 import preprocess_input
+from keras.models import Model
+from keras.preprocessing import image
+from PIL import Image  # was: from scipy.misc import imresize
+from sklearn.decomposition import PCA
 
 import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.utils as htk_utils
-
 import large_image
-
-from keras.models import Model
-from keras.preprocessing import image
-from keras.applications.vgg16 import preprocess_input
-from keras import applications
-
 from ctk_cli import CLIArgumentParser
-from PIL import Image  # was: from scipy.misc import imresize
-from sklearn.decomposition import PCA
-import joblib  # was: from sklearn.externals import joblib
-
 from histomicstk.cli import utils as cli_utils
-
-import logging
 
 logging.basicConfig(level=logging.CRITICAL)
 

--- a/scripts/H5DataSet.py
+++ b/scripts/H5DataSet.py
@@ -1,6 +1,7 @@
 import h5py as h5
 import numpy as np
 
+
 """
 H5DataSet class
 

--- a/scripts/Predict.py
+++ b/scripts/Predict.py
@@ -48,8 +48,10 @@ python Predict.py -h
 """
 
 import argparse
+
 import h5py as h5
 import numpy as np
+
 import networks
 
 

--- a/scripts/SuperpixelSegmentation.py
+++ b/scripts/SuperpixelSegmentation.py
@@ -42,28 +42,24 @@ python SuperpixelSegmentation.py --projectName path/to/myproject --superpixelSiz
 
 """
 
-import os
 import json
+import logging
+import os
 import time
+
 import h5py
-
 import numpy as np
-import dask
-
-import histomicstk.preprocessing.color_normalization as htk_cnorm
-import histomicstk.segmentation as htk_seg
-import histomicstk.utils as htk_utils
-
-import large_image
-
-from ctk_cli import CLIArgumentParser
 from scipy import ndimage
 from skimage.measure import regionprops
 from skimage.segmentation import slic
 
+import dask
+import histomicstk.preprocessing.color_normalization as htk_cnorm
+import histomicstk.segmentation as htk_seg
+import histomicstk.utils as htk_utils
+import large_image
+from ctk_cli import CLIArgumentParser
 from histomicstk.cli import utils as cli_utils
-
-import logging
 
 logging.basicConfig(level=logging.CRITICAL)
 

--- a/scripts/networks.py
+++ b/scripts/networks.py
@@ -1,6 +1,7 @@
 import numpy as np
 import tensorflow as tf
 
+
 """
 Network class
 

--- a/test/check.py
+++ b/test/check.py
@@ -17,9 +17,11 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Any, Sequence, Union
+
 import numpy as np
 from numpy.typing import NDArray
-from typing import Any, Sequence, Union
 
 NDArrayFloat = NDArray[np.float_]
 NDArrayInt = NDArray[np.int_]

--- a/test/create.py
+++ b/test/create.py
@@ -17,9 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import List, Mapping, Optional, Tuple
+
 import numpy as np
+
 from check import NDArrayFloat, NDArrayInt, SequenceFloat, SequenceInt
-from typing import Mapping, List, Optional, Tuple
 
 
 def create_dataset(

--- a/test/exercise.py
+++ b/test/exercise.py
@@ -17,11 +17,13 @@
 # ==========================================================================
 
 from __future__ import annotations
-import numpy as np
-from create import create_dataset
-from create import create_toy_pytorch_model
-from create import create_toy_tensorflow_model
+
 from typing import List
+
+import numpy as np
+
+from create import (create_dataset, create_toy_pytorch_model,
+                    create_toy_tensorflow_model)
 
 
 def exercise_dataset_handler(

--- a/test/test_0010_dataset_handler_interface.py
+++ b/test/test_0010_dataset_handler_interface.py
@@ -17,10 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Any, Mapping, Type
+
 import al_bench as alb
 import al_bench.dataset
 from exercise import exercise_dataset_handler
-from typing import Any, Mapping, Type
 
 
 def test_0010_dataset_handler_interface() -> None:

--- a/test/test_0020_model_handler_interface.py
+++ b/test/test_0020_model_handler_interface.py
@@ -17,10 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Any, Mapping, Type
+
 import al_bench as alb
 import al_bench.model
 from exercise import exercise_model_handler
-from typing import Any, Mapping, Type
 
 
 def test_0020_model_handler_interface() -> None:

--- a/test/test_0030_strategy_handler_interface.py
+++ b/test/test_0030_strategy_handler_interface.py
@@ -17,10 +17,12 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Any, Mapping, Type
+
 import al_bench as alb
 import al_bench.strategy
 from exercise import exercise_strategy_handler
-from typing import Any, Mapping, Type
 
 
 def test_0030_strategy_handler_interface() -> None:

--- a/test/test_0040_factory.py
+++ b/test/test_0040_factory.py
@@ -17,11 +17,14 @@
 # ==========================================================================
 
 from __future__ import annotations
+
+from typing import Sequence
+
 import numpy as np
+
 import al_bench as alb
 import al_bench.factory
-from check import deep_print, NDArrayFloat
-from typing import Sequence
+from check import NDArrayFloat, deep_print
 
 
 def test_0040_factory() -> None:

--- a/test/test_0050_factory.py
+++ b/test/test_0050_factory.py
@@ -17,15 +17,17 @@
 # ==========================================================================
 
 from __future__ import annotations
-import al_bench as alb
-import al_bench.factory
+
+from typing import Any, Mapping
+
 import numpy as np
 import torch
-from check import deeply_allclose, deep_print, NDArrayFloat, NDArrayInt
+
+import al_bench as alb
+import al_bench.factory
+from check import NDArrayFloat, NDArrayInt, deep_print, deeply_allclose
 from create import create_dirichlet_predictions
-from data_0050_factory import best_cutoffs
-from data_0050_factory import expected_certainties
-from typing import Any, Mapping
+from data_0050_factory import best_cutoffs, expected_certainties
 
 
 def test_0050_factory() -> None:

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -17,18 +17,21 @@
 # ==========================================================================
 
 from __future__ import annotations
-import al_bench as alb
-import al_bench.strategy
+
 import datetime
-import numpy as np
 import os
 import random
 import re
-from check import check_deeply_numeric, NDArrayFloat, NDArrayInt
-from create import create_dataset_4598_1280_4
-from create import create_pytorch_model_with_dropout
-from create import create_tensorflow_model_with_dropout
-from typing import Any, Mapping, List, Match, Optional, Type
+from typing import Any, List, Mapping, Match, Optional, Type
+
+import numpy as np
+
+import al_bench as alb
+import al_bench.strategy
+from check import NDArrayFloat, NDArrayInt, check_deeply_numeric
+from create import (create_dataset_4598_1280_4,
+                    create_pytorch_model_with_dropout,
+                    create_tensorflow_model_with_dropout)
 
 
 def test_0100_handler_combinations() -> None:

--- a/test/test_0120_bayesian_model.py
+++ b/test/test_0120_bayesian_model.py
@@ -17,18 +17,21 @@
 # ==========================================================================
 
 from __future__ import annotations
-import al_bench as alb
-import al_bench.strategy
+
+import os
+import random
+import shutil
+from typing import List, Mapping, Tuple
+
 import batchbald_redux as bbald
 import batchbald_redux.consistent_mc_dropout
 import batchbald_redux.repeated_mnist
 import numpy as np
-import os
-import random
-import shutil
 import torch
+
+import al_bench as alb
+import al_bench.strategy
 from check import NDArrayFloat, NDArrayInt
-from typing import Mapping, List, Tuple
 
 
 class BayesianCNN(bbald.consistent_mc_dropout.BayesianModule):


### PR DESCRIPTION
Specifically, `isort` followed by `black -C` is run on each Python file.  We thus get which line follows which line as dictated by `isort` but the within-line formatting as dictated by `black`.

Also, update some comments.