### PR TITLE
Restore machine-learning optional package dependencies

### DIFF
--- a/al_bench/factory.py
+++ b/al_bench/factory.py
@@ -154,6 +154,8 @@ class ComputeCertainty:
             # the remaining will be rated as more certain via a constant.
             batch_size: int = min(self.batchbald_batch_size, predictions.shape[0])
             num_samples: int = self.batchbald_num_samples
+            epsilon = 7.8886090522101180541e-31
+            predictions[predictions < epsilon] = epsilon
             log_predictions = np.log(predictions)
             with torch.no_grad():
                 bald: bbald.batchbald.CandidateBatch

--- a/al_bench/model.py
+++ b/al_bench/model.py
@@ -205,9 +205,8 @@ class _AbstractCommon:
                         predictions: NDArray[np.float_]
                         predictions = np.concatenate(predictions_list, axis=0)
                         predictions_list = list()
-                        statistcs: Mapping[
-                            str, Mapping[float, float]
-                        ] = self.model_handler.compute_certainty_statistics(
+                        statistcs: Mapping[str, Mapping[float, float]]
+                        statistcs = self.model_handler.compute_certainty_statistics(
                             predictions, percentiles
                         )
                         # Report percentile scores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ dependencies = [
 ]
 dynamic = ["version", "description"]
 
-# [project.optional-dependencies]
-# torch = ["torch>=1.11,<2.0"]
-# tensorflow = ["tensorflow>=2.6,<3.0"]
+[project.optional-dependencies]
+torch = ["torch>=1.11,<2.0"]    # Use e.g. --extra-index-url https://download.pytorch.org/whl/cu117
+tensorflow = ["tensorflow>=2.6,<3.0"]
 
 [project.urls]
 Source = "https://github.com/DigitalSlideArchive/ALBench"

--- a/scripts/FeatureExtraction.py
+++ b/scripts/FeatureExtraction.py
@@ -48,7 +48,6 @@ import os
 import time
 
 import h5py
-import joblib  # was: from sklearn.externals import joblib
 import numpy as np
 import pandas as pd
 from keras import applications
@@ -56,13 +55,14 @@ from keras.applications.vgg16 import preprocess_input
 from keras.models import Model
 from keras.preprocessing import image
 from PIL import Image  # was: from scipy.misc import imresize
-from sklearn.decomposition import PCA
 
 import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.utils as htk_utils
+import joblib  # was: from sklearn.externals import joblib
 import large_image
 from ctk_cli import CLIArgumentParser
 from histomicstk.cli import utils as cli_utils
+from sklearn.decomposition import PCA
 
 logging.basicConfig(level=logging.CRITICAL)
 
@@ -397,10 +397,9 @@ def main(args):  # noqa: C901
 
                     start_time = time.time()
 
-                    (
-                        im_fgnd_mask_lres,
-                        fgnd_seg_scale,
-                    ) = cli_utils.segment_wsi_foreground_at_low_res(ts)
+                    (im_fgnd_mask_lres, fgnd_seg_scale) = (
+                        cli_utils.segment_wsi_foreground_at_low_res(ts)
+                    )
 
                     fgnd_time = time.time() - start_time
 
@@ -475,35 +474,31 @@ def main(args):  # noqa: C901
 
                         # detect superpixel data
                         if args.inputPCAModel:
-                            (
-                                tile_features,
-                                tile_x_centroids,
-                                tile_y_centroids,
-                            ) = compute_superpixel_data_pca(
-                                model,
-                                pca,
-                                img_paths[i],
-                                tile_position,
-                                centroid_paths[j],
-                                args,
-                                it_kwargs,
-                                src_mu_lab,
-                                src_sigma_lab,
+                            (tile_features, tile_x_centroids, tile_y_centroids) = (
+                                compute_superpixel_data_pca(
+                                    model,
+                                    pca,
+                                    img_paths[i],
+                                    tile_position,
+                                    centroid_paths[j],
+                                    args,
+                                    it_kwargs,
+                                    src_mu_lab,
+                                    src_sigma_lab,
+                                )
                             )
                         else:
-                            (
-                                tile_features,
-                                tile_x_centroids,
-                                tile_y_centroids,
-                            ) = compute_superpixel_data(
-                                model,
-                                img_paths[i],
-                                tile_position,
-                                centroid_paths[j],
-                                args,
-                                it_kwargs,
-                                src_mu_lab,
-                                src_sigma_lab,
+                            (tile_features, tile_x_centroids, tile_y_centroids) = (
+                                compute_superpixel_data(
+                                    model,
+                                    img_paths[i],
+                                    tile_position,
+                                    centroid_paths[j],
+                                    args,
+                                    it_kwargs,
+                                    src_mu_lab,
+                                    src_sigma_lab,
+                                )
                             )
 
                         print(f"tile_position = {tile_position}")

--- a/scripts/SuperpixelSegmentation.py
+++ b/scripts/SuperpixelSegmentation.py
@@ -50,8 +50,6 @@ import time
 import h5py
 import numpy as np
 from scipy import ndimage
-from skimage.measure import regionprops
-from skimage.segmentation import slic
 
 import dask
 import histomicstk.preprocessing.color_normalization as htk_cnorm
@@ -60,6 +58,8 @@ import histomicstk.utils as htk_utils
 import large_image
 from ctk_cli import CLIArgumentParser
 from histomicstk.cli import utils as cli_utils
+from skimage.measure import regionprops
+from skimage.segmentation import slic
 
 logging.basicConfig(level=logging.CRITICAL)
 
@@ -289,10 +289,9 @@ def main(args):  # noqa: C901
 
             start_time = time.time()
 
-            (
-                im_fgnd_mask_lres,
-                fgnd_seg_scale,
-            ) = cli_utils.segment_wsi_foreground_at_low_res(ts)
+            (im_fgnd_mask_lres, fgnd_seg_scale) = (
+                cli_utils.segment_wsi_foreground_at_low_res(ts)
+            )
 
             fgnd_time = time.time() - start_time
 

--- a/test/exercise.py
+++ b/test/exercise.py
@@ -22,8 +22,7 @@ from typing import List
 
 import numpy as np
 
-from create import (create_dataset, create_toy_pytorch_model,
-                    create_toy_tensorflow_model)
+from create import create_dataset, create_toy_pytorch_model, create_toy_tensorflow_model
 
 
 def exercise_dataset_handler(

--- a/test/test_0100_handler_combinations.py
+++ b/test/test_0100_handler_combinations.py
@@ -29,9 +29,11 @@ import numpy as np
 import al_bench as alb
 import al_bench.strategy
 from check import NDArrayFloat, NDArrayInt, check_deeply_numeric
-from create import (create_dataset_4598_1280_4,
-                    create_pytorch_model_with_dropout,
-                    create_tensorflow_model_with_dropout)
+from create import (
+    create_dataset_4598_1280_4,
+    create_pytorch_model_with_dropout,
+    create_tensorflow_model_with_dropout,
+)
 
 
 def test_0100_handler_combinations() -> None:


### PR DESCRIPTION
1. Tensorflow and Torch can now be installed via `pip install 'al_bench[tensorflow,torch]' --extra-index-url https://download.pytorch.org/whl/cu117`.  This will get the `CUDA 11.7` version of `torch`.
2. Prediction probability of zero is now treated as 2**(-100) so that it has a valid logarithm
3. Reformat with `isort` and `black -C`